### PR TITLE
HomeScreen 깜빡임 수정

### DIFF
--- a/app/src/main/java/com/gyleedev/githubsearch/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/home/HomeScreen.kt
@@ -165,7 +165,7 @@ fun HomeScreen(
         },
         modifier = modifier.fillMaxSize(),
 
-        ) { paddingValues ->
+    ) { paddingValues ->
 
         when (users.loadState.refresh) {
             is LoadState.Loading -> {
@@ -343,7 +343,7 @@ fun EmbeddedSearchBar(
             user = user,
             onClick = moveToDetail,
             modifier = Modifier,
-            onUserUpdate = { onUserUpdate() }
+            onUserUpdate = { onUserUpdate() },
         )
 
         if (loading) {


### PR DESCRIPTION
-  홈화면 깜빡임 수정 관련
 - SearchResultItem onUserUpdate 람다 추가 
 - user 정보가 들어왔을 때 onUserUpdate 실행
 - EmbeddedSearchBar에 onUserUpdate 람다 추가
 - EmbeddedSearBar에서 onUserUpdate일 때 users pagingItem 강제로 리프레쉬
 - HomeScreen의 최상위에 users.refresh() 제거
- 린트 맞춤 (spotlessApply 적용)
- close #51 