### PR TITLE
Refactor(Home) : 홈 화면 Material 3 마이그레이션 및 상태 관리 구조 개선

### DIFF
--- a/app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt
@@ -2,33 +2,27 @@ package com.gyleedev.githubsearch.ui
 
 import android.os.Build
 import androidx.annotation.RequiresExtension
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material.BottomNavigationItem
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Details
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.Gray
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -74,15 +68,14 @@ fun GithubSearchScreen(
                 BottomNavigation(navController = navController, modifier = Modifier)
             }
         },
-        modifier = Modifier.navigationBarsPadding(),
+        // Scaffold가 자동으로 주입하는 inset 무시
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
     ) { innerPadding ->
         NavHost(
             navController = navController,
             startDestination = BottomNavItem.Home.screenRoute,
-            modifier =
-            modifier
-                .padding(bottom = innerPadding.calculateBottomPadding())
-                .statusBarsPadding(),
+            modifier = modifier
+                .consumeWindowInsets(innerPadding),
         ) {
             composable(route = BottomNavItem.Home.screenRoute) {
                 HomeScreen(
@@ -120,9 +113,7 @@ fun GithubSearchScreen(
                 SettingScreen(
                     requestAuthentication = { onAuthenticationRequest() },
                     versionName = BuildConfig.VERSION_NAME,
-                    modifier =
-                    Modifier
-                        .fillMaxSize(),
+                    modifier = Modifier.fillMaxSize(),
                 )
             }
         }
@@ -140,32 +131,21 @@ fun BottomNavigation(
             BottomNavItem.Favorite,
             BottomNavItem.Setting,
         )
-
-    androidx.compose.material.BottomNavigation(
-        backgroundColor = MaterialTheme.colorScheme.background,
-        contentColor = MaterialTheme.colorScheme.onBackground,
-        modifier = modifier,
+    NavigationBar(
+        modifier = modifier.fillMaxWidth(),
     ) {
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = navBackStackEntry?.destination?.route
 
         items.forEach { item ->
-            BottomNavigationItem(
+            NavigationBarItem(
                 icon = {
                     Icon(
                         imageVector = item.icons,
                         contentDescription = stringResource(id = item.title),
-                        modifier =
-                        Modifier
-                            .width(26.dp)
-                            .height(26.dp),
                     )
                 },
-                label = { Text(stringResource(id = item.title), fontSize = 9.sp) },
-                selectedContentColor = MaterialTheme.colorScheme.primary,
-                unselectedContentColor = Gray,
                 selected = currentRoute == item.screenRoute,
-                alwaysShowLabel = false,
                 onClick = {
                     navController.navigate(item.screenRoute) {
                         navController.graph.startDestinationRoute?.let {

--- a/app/src/main/java/com/gyleedev/githubsearch/ui/MainActivity.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/MainActivity.kt
@@ -29,13 +29,7 @@ class MainActivity : AppCompatActivity() {
     @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge(
-            statusBarStyle =
-            SystemBarStyle.auto(
-                darkScrim = android.graphics.Color.TRANSPARENT,
-                lightScrim = android.graphics.Color.TRANSPARENT,
-            ),
-        )
+        enableEdgeToEdge()
         setContent {
             GithubSearchTheme {
                 GithubSearchScreen(

--- a/data/src/main/java/com/gyleedev/data/repository/GitHubRepositoryImpl.kt
+++ b/data/src/main/java/com/gyleedev/data/repository/GitHubRepositoryImpl.kt
@@ -28,7 +28,7 @@ import com.gyleedev.githubsearch.domain.model.RepositoryModel
 import com.gyleedev.githubsearch.domain.model.RevokeRequestBody
 import com.gyleedev.githubsearch.domain.model.SearchStatus
 import com.gyleedev.githubsearch.domain.model.UserModel
-import com.gyleedev.githubsearch.domain.model.UserWrapper
+import com.gyleedev.githubsearch.domain.model.UserSearchResult
 import com.gyleedev.githubsearch.domain.repository.GitHubRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -77,28 +77,28 @@ constructor(
     }
 
     // Home에서 user정보를 요청하는 함수
-    override suspend fun getUserAtHome(id: String): UserWrapper = withContext(Dispatchers.IO) {
+    override suspend fun getUserAtHome(id: String): UserSearchResult = withContext(Dispatchers.IO) {
         val user = userDao.getUserByGithubId(id)
         if (user != null) {
-            UserWrapper.FromDatabase(data = user.toModel())
+            UserSearchResult.FromDatabase(data = user.toModel())
         } else {
             getUserFromGithub(id)
         }
     }
 
-    private suspend fun getUserFromGithub(id: String): UserWrapper = try {
+    private suspend fun getUserFromGithub(id: String): UserSearchResult = try {
         val userResponse = githubApiService.getUser(id)
-        UserWrapper.Success(
+        UserSearchResult.Success(
             status = SearchStatus.SUCCESS,
             data = userResponse.toModel(),
         )
     } catch (e: Exception) {
         val status = exceptionToStatusUtil(e)
-        UserWrapper.Failure(
+        UserSearchResult.Failure(
             status = status,
         )
     } catch (e: UnknownError) {
-        UserWrapper.Failure(
+        UserSearchResult.Failure(
             status = SearchStatus.BAD_NETWORK,
         )
     }
@@ -119,31 +119,31 @@ constructor(
     }
 
     // 유저정보 없거나 오래됐을때 깃헙에서 유저정보 가져오기
-    private suspend fun insertUserFromGithub(id: String): UserWrapper = try {
+    private suspend fun insertUserFromGithub(id: String): UserSearchResult = try {
         val userRemote = githubApiService.getUser(id)
         val entityId = userDao.insertUser(userRemote.toModel().toEntity())
         insertRepos(id, entityId)
         updateAccessTime(id)
-        UserWrapper.Success(
+        UserSearchResult.Success(
             status = SearchStatus.SUCCESS,
             data = userRemote.toModel(),
         )
     } catch (e: Exception) {
         val status = exceptionToStatusUtil(e)
-        UserWrapper.Failure(
+        UserSearchResult.Failure(
             status = status,
         )
     } catch (e: UnknownError) {
-        UserWrapper.Failure(
+        UserSearchResult.Failure(
             status = SearchStatus.BAD_NETWORK,
         )
     }
 
-    private suspend fun updateUserFromGithub(id: String): UserWrapper {
+    private suspend fun updateUserFromGithub(id: String): UserSearchResult {
         try {
             val userResponse = githubApiService.getUser(id)
             val userRemote =
-                UserWrapper.Success(
+                UserSearchResult.Success(
                     status = SearchStatus.SUCCESS,
                     data = userResponse.toModel(),
                 )
@@ -179,11 +179,11 @@ constructor(
             }
         } catch (e: Exception) {
             val status = exceptionToStatusUtil(e)
-            return UserWrapper.Failure(
+            return UserSearchResult.Failure(
                 status = status,
             )
         } catch (e: UnknownError) {
-            return UserWrapper.Failure(
+            return UserSearchResult.Failure(
                 status = SearchStatus.BAD_NETWORK,
             )
         }
@@ -231,13 +231,13 @@ constructor(
         }
     }
 
-    override suspend fun getDetailUser(githubId: String): UserWrapper = withContext(Dispatchers.IO) {
+    override suspend fun getDetailUser(githubId: String): UserSearchResult = withContext(Dispatchers.IO) {
         val lastAccess = getLastAccessById(githubId)
         if (lastAccess != null) {
             if (Instant.now().toEpochMilli() - lastAccess.accessTime.toEpochMilli() < 3600000) {
                 val user = getUser(githubId)
                 if (user != null) {
-                    UserWrapper.FromDatabase(
+                    UserSearchResult.FromDatabase(
                         data = user,
                     )
                 } else {
@@ -251,7 +251,7 @@ constructor(
         }
     }
 
-    override suspend fun updateUserFavorite(id: String): UserWrapper = try {
+    override suspend fun updateUserFavorite(id: String): UserSearchResult = try {
         val user = userDao.getUser(id)
         if (user != null) {
             userDao.updateUser(
@@ -275,17 +275,17 @@ constructor(
             )
             val updatedUser = userDao.getUser(id)
             if (updatedUser != null) {
-                UserWrapper.FromDatabase(
+                UserSearchResult.FromDatabase(
                     data = updatedUser.toModel(),
                 )
             } else {
-                UserWrapper.Failure(status = SearchStatus.BAD_NETWORK)
+                UserSearchResult.Failure(status = SearchStatus.BAD_NETWORK)
             }
         } else {
-            UserWrapper.Failure(status = SearchStatus.BAD_NETWORK)
+            UserSearchResult.Failure(status = SearchStatus.BAD_NETWORK)
         }
     } catch (e: Exception) {
-        UserWrapper.Failure(status = SearchStatus.BAD_NETWORK)
+        UserSearchResult.Failure(status = SearchStatus.BAD_NETWORK)
     }
 
     override suspend fun getAccessToken(code: String): GithubAccessModel? {

--- a/docs/plan/TYPE_SAFE_NAVIGATION_MIGRATION_PLAN.md
+++ b/docs/plan/TYPE_SAFE_NAVIGATION_MIGRATION_PLAN.md
@@ -1,0 +1,16 @@
+# Type-Safe Navigation 마이그레이션 전략
+
+## 1. 플러그인 및 의존성 추가
+* `libs.versions.toml`에 `kotlinx-serialization-json` 라이브러리와 `org.jetbrains.kotlin.plugin.serialization` 플러그인을 추가합니다.
+* `app` 모듈 및 필요한 기능 모듈의 `build.gradle.kts` (또는 컨벤션 플러그인)에 해당 의존성을 적용합니다.
+
+## 2. Type-Safe Route 정의 (경로 객체화)
+* 기존의 `String` 상수(예: "home", "detail/{id}") 대신 `@Serializable` 어노테이션이 붙은 `Data Object` 또는 `Data Class`를 정의합니다.
+* 예시: `data object Home`, `@Serializable data class Detail(val id: String)`
+
+## 3. 네비게이션 그래프(GithubSearchScreen.kt) 리팩터링
+* `NavHost` 내부의 `composable("route")` 블록을 `composable<RouteObject>` 형태로 변경합니다.
+* 상세 화면으로 이동할 때 문자열 템플릿("detail/$id")을 사용하는 대신 인스턴스를 전달(`navController.navigate(Detail(id))`)하도록 수정합니다.
+
+## 4. BottomNavigation (바텀 네비게이션) 로직 수정
+* 현재 백스택 상태(`currentBackStackEntryAsState`)에서 현재 경로를 확인하는 방식을, Type-Safe 객체의 클래스 이름(`route::class.qualifiedName`) 등을 검사하는 방식으로 수정하여 호환성을 맞춥니다.

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/model/UserSearchResult.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/model/UserSearchResult.kt
@@ -1,16 +1,16 @@
 package com.gyleedev.githubsearch.domain.model
 
-sealed interface UserWrapper {
+sealed interface UserSearchResult {
     data class FromDatabase(
         val data: UserModel,
-    ) : UserWrapper
+    ) : UserSearchResult
 
     data class Success(
         val status: SearchStatus,
         val data: UserModel,
-    ) : UserWrapper
+    ) : UserSearchResult
 
     data class Failure(
         val status: SearchStatus,
-    ) : UserWrapper
+    ) : UserSearchResult
 }

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/repository/GitHubRepository.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/repository/GitHubRepository.kt
@@ -6,13 +6,13 @@ import com.gyleedev.githubsearch.domain.model.FilterStatus
 import com.gyleedev.githubsearch.domain.model.GithubAccessModel
 import com.gyleedev.githubsearch.domain.model.RepositoryModel
 import com.gyleedev.githubsearch.domain.model.UserModel
-import com.gyleedev.githubsearch.domain.model.UserWrapper
+import com.gyleedev.githubsearch.domain.model.UserSearchResult
 import kotlinx.coroutines.flow.Flow
 
 interface GitHubRepository {
     fun getUsers(): Flow<PagingData<UserModel>>
 
-    suspend fun getUserAtHome(id: String): UserWrapper
+    suspend fun getUserAtHome(id: String): UserSearchResult
 
     suspend fun getLastAccessById(id: String): AccessTime?
 
@@ -20,9 +20,9 @@ interface GitHubRepository {
 
     suspend fun getReposFromDatabase(githubId: String): List<RepositoryModel>?
 
-    suspend fun getDetailUser(githubId: String): UserWrapper
+    suspend fun getDetailUser(githubId: String): UserSearchResult
 
-    suspend fun updateUserFavorite(id: String): UserWrapper
+    suspend fun updateUserFavorite(id: String): UserSearchResult
 
     fun getFavorites(status: FilterStatus): Flow<PagingData<UserModel>>
 

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/GetUserFeedUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/GetUserFeedUseCase.kt
@@ -1,7 +1,7 @@
 package com.gyleedev.githubsearch.domain.usecase
 
 import com.gyleedev.githubsearch.domain.model.DetailFeed
-import com.gyleedev.githubsearch.domain.model.UserWrapper
+import com.gyleedev.githubsearch.domain.model.UserSearchResult
 import com.gyleedev.githubsearch.domain.repository.GitHubRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -15,15 +15,15 @@ constructor(
     suspend operator fun invoke(id: String): List<DetailFeed> = withContext(Dispatchers.IO) {
         val userModel =
             when (val user = repository.getDetailUser(id)) {
-                is UserWrapper.FromDatabase -> {
+                is UserSearchResult.FromDatabase -> {
                     user.data
                 }
 
-                is UserWrapper.Success -> {
+                is UserSearchResult.Success -> {
                     user.data
                 }
 
-                is UserWrapper.Failure -> {
+                is UserSearchResult.Failure -> {
                     null
                 }
             }

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/SearchUserUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/SearchUserUseCase.kt
@@ -1,6 +1,6 @@
 package com.gyleedev.githubsearch.domain.usecase
 
-import com.gyleedev.githubsearch.domain.model.UserWrapper
+import com.gyleedev.githubsearch.domain.model.UserSearchResult
 import com.gyleedev.githubsearch.domain.repository.GitHubRepository
 import javax.inject.Inject
 
@@ -9,5 +9,5 @@ class SearchUserUseCase
 constructor(
     private val repository: GitHubRepository,
 ) {
-    suspend operator fun invoke(user: String): UserWrapper = repository.getUserAtHome(user)
+    suspend operator fun invoke(user: String): UserSearchResult = repository.getUserAtHome(user)
 }

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/UpdateFavoriteStatusAndRefreshFeedUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/UpdateFavoriteStatusAndRefreshFeedUseCase.kt
@@ -1,7 +1,7 @@
 package com.gyleedev.githubsearch.domain.usecase
 
 import com.gyleedev.githubsearch.domain.model.DetailFeed
-import com.gyleedev.githubsearch.domain.model.UserWrapper
+import com.gyleedev.githubsearch.domain.model.UserSearchResult
 import com.gyleedev.githubsearch.domain.repository.GitHubRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -16,7 +16,7 @@ constructor(
         val user = repository.updateUserFavorite(id)
         val repo = repository.getReposFromDatabase(id)
         val userModel =
-            if (user is UserWrapper.FromDatabase) {
+            if (user is UserSearchResult.FromDatabase) {
                 user.data
             } else {
                 null

--- a/feature/detail/build.gradle.kts
+++ b/feature/detail/build.gradle.kts
@@ -15,3 +15,4 @@ dependencies {
     implementation(libs.landscapist.placeholder)
     implementation(libs.androidx.material.icons)
 }
+composeCompiler { reportsDestination = layout.buildDirectory.dir("compose_reports") }

--- a/feature/favorite/build.gradle.kts
+++ b/feature/favorite/build.gradle.kts
@@ -16,3 +16,4 @@ dependencies {
     implementation(libs.paging.compose)
     implementation(libs.androidx.material.icons)
 }
+composeCompiler { reportsDestination = layout.buildDirectory.dir("compose_reports") }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -16,3 +16,4 @@ dependencies {
     implementation(libs.paging.compose)
     implementation(libs.androidx.material.icons)
 }
+composeCompiler { reportsDestination = layout.buildDirectory.dir("compose_reports") }

--- a/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeScreen.kt
@@ -1,7 +1,6 @@
 package com.gyleedev.githubsearch.feature.home
 
 import android.os.Build
-import android.widget.Toast
 import androidx.annotation.RequiresExtension
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.clickable
@@ -9,9 +8,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
@@ -31,7 +33,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
-import androidx.compose.material3.Surface
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -50,7 +54,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.gyleedev.githubsearch.domain.model.FetchState
@@ -72,21 +75,18 @@ fun HomeScreen(
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val users = viewModel.users.collectAsLazyPagingItems()
-    val user by viewModel.userInfo.collectAsStateWithLifecycle()
-    val loading by viewModel.loading.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    val query by viewModel.searchQuery.collectAsStateWithLifecycle()
 
     val unknownHostException = stringResource(id = DesignSystemR.string.unknown_host_exception)
     val socketException = stringResource(id = DesignSystemR.string.socket_exception)
     val httpException = stringResource(id = DesignSystemR.string.http_exception)
     val etcException = stringResource(id = DesignSystemR.string.etc_exception)
     val noSuchUserMessage = stringResource(id = HomeR.string.search_result_no_user)
+    val snackBarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         viewModel.fetchState.collect { fetchState ->
-            viewModel.stopLoading()
             val message =
                 when (fetchState) {
                     FetchState.WRONG_CONNECTION -> unknownHostException
@@ -94,7 +94,10 @@ fun HomeScreen(
                     FetchState.PARSE_ERROR -> httpException
                     FetchState.FAIL -> etcException
                 }
-            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            snackBarHostState.showSnackbar(
+                message = message,
+                duration = SnackbarDuration.Short
+            )
         }
     }
 
@@ -102,21 +105,17 @@ fun HomeScreen(
         viewModel.errorAlert.collect { status ->
             when (status) {
                 SearchStatus.NO_SUCH_USER -> {
-                    Toast
-                        .makeText(
-                            context,
-                            noSuchUserMessage,
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                    snackBarHostState.showSnackbar(
+                        message = noSuchUserMessage,
+                        duration = SnackbarDuration.Short
+                    )
                 }
 
                 SearchStatus.BAD_NETWORK -> {
-                    Toast
-                        .makeText(
-                            context,
-                            httpException,
-                            Toast.LENGTH_SHORT,
-                        ).show()
+                    snackBarHostState.showSnackbar(
+                        message = httpException,
+                        duration = SnackbarDuration.Short
+                    )
                 }
 
                 else -> {
@@ -138,88 +137,67 @@ fun HomeScreen(
     LaunchedEffect(isSearchActive) {
         requestBottomBarStatus(isSearchActive)
     }
+    if (uiState is HomeUiState.Success) {
+        Scaffold(
+            topBar = {
+                EmbeddedSearchBar(
+                    onQueryChange = viewModel::updateSearchId,
+                    isSearchActive = isSearchActive,
+                    query = (uiState as HomeUiState.Success).searchQuery,
+                    onActiveChanged = { isSearchActive = it },
+                    onSearch = viewModel::getUser,
+                    onSearchItemReset = viewModel::resetQuery,
+                    moveToDetail = { (uiState as HomeUiState.Success).searchedUser?.let { moveToDetail(it.login) } },
+                    user = (uiState as HomeUiState.Success).searchedUser,
+                    loading = (uiState as HomeUiState.Success).isLoading,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            },
+            snackbarHost = { SnackbarHost(hostState = snackBarHostState) },
+            modifier = modifier.fillMaxSize(),
+        ) { paddingValues ->
 
-    Scaffold(
-        topBar = {
-            EmbeddedSearchBar(
-                onQueryChange = viewModel::updateSearchId,
-                isSearchActive = isSearchActive,
-                query = query,
-                onActiveChanged = { isSearchActive = it },
-                onSearch = viewModel::getUser,
-                onSearchItemReset = viewModel::resetUser,
-                moveToDetail = { user?.let { moveToDetail(it.login) } },
-                user = user,
-                loading = loading,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        },
-        modifier = modifier.fillMaxSize(),
-    ) { paddingValues ->
-
-        when (users.loadState.refresh) {
-            is LoadState.Loading -> {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    Box(
-                        modifier = Modifier,
-                        Alignment.Center,
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier)
-                    }
-                }
-            }
-
-            is LoadState.Error -> {
+            if (users.itemCount > 0) {
+                SearchItemList(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(paddingValues),
+                    users = users,
+                    onClick = { moveToDetail(it) },
+                )
+            } else {
                 NoItem(
                     modifier = Modifier.padding(paddingValues),
                 )
             }
 
-            else -> {
-                if (users.itemCount > 0) {
-                    SearchItemList(
-                        modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(paddingValues),
-                        users = users,
-                        onClick = { moveToDetail(it) },
-                    )
-                } else {
-                    NoItem(
-                        modifier = Modifier.padding(paddingValues),
-                    )
-                }
+            if (showRequestAuthenticationDialog) {
+                AlertDialog(
+                    onDismissRequest = { showRequestAuthenticationDialog = false },
+                    title = { Text(text = stringResource(id = DesignSystemR.string.title_request_authentication)) },
+                    text = { Text(text = stringResource(id = DesignSystemR.string.content_request_authentication)) },
+                    confirmButton = {
+                        Button(
+                            onClick = {
+                                showRequestAuthenticationDialog = false
+                                requestAuthentication()
+                            },
+                        ) {
+                            Text(stringResource(id = DesignSystemR.string.text_dialog_confirm))
+                        }
+                    },
+                    dismissButton = {
+                        Button(
+                            onClick = {
+                                showRequestAuthenticationDialog = false
+                            },
+                        ) {
+                            Text(stringResource(id = DesignSystemR.string.text_dialog_cancel))
+                        }
+                    },
+                )
             }
-        }
-
-        if (showRequestAuthenticationDialog) {
-            AlertDialog(
-                onDismissRequest = { showRequestAuthenticationDialog = false },
-                title = { Text(text = stringResource(id = DesignSystemR.string.title_request_authentication)) },
-                text = { Text(text = stringResource(id = DesignSystemR.string.content_request_authentication)) },
-                confirmButton = {
-                    Button(
-                        onClick = {
-                            showRequestAuthenticationDialog = false
-                            requestAuthentication()
-                        },
-                    ) {
-                        Text(stringResource(id = DesignSystemR.string.text_dialog_confirm))
-                    }
-                },
-                dismissButton = {
-                    Button(
-                        onClick = {
-                            showRequestAuthenticationDialog = false
-                        },
-                    ) {
-                        Text(stringResource(id = DesignSystemR.string.text_dialog_cancel))
-                    }
-                },
-            )
         }
     }
 }
@@ -239,93 +217,95 @@ private fun EmbeddedSearchBar(
     modifier: Modifier = Modifier,
 ) {
     val animatePadding by animateDpAsState(
-        targetValue = if (isSearchActive) 0.dp else 20.dp,
+        targetValue = if (isSearchActive) 0.dp else 24.dp,
         label = "animatePadding",
     )
-
     SearchBar(
-        query = query,
-        onQueryChange = { changedQuery ->
-            onQueryChange(changedQuery)
+        inputField = {
+            SearchBarDefaults.InputField(
+                query = query,
+                onQueryChange = onQueryChange,
+                onSearch = onSearch,
+                expanded = isSearchActive,
+                onExpandedChange = onActiveChanged,
+                placeholder = { Text(text = "search") },
+                leadingIcon = {
+                    if (isSearchActive) {
+                        IconButton(
+                            onClick = {
+                                onActiveChanged(false)
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    } else {
+                        Icon(
+                            imageVector = Icons.Rounded.Search,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                },
+                trailingIcon = {
+                    if (isSearchActive && query.isNotEmpty()) {
+                        IconButton(
+                            onClick = {
+                                onQueryChange("")
+                                onSearchItemReset()
+                            },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.Close,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                },
+            )
         },
-        onSearch = onSearch,
-        active = isSearchActive,
-        onActiveChange = { onActiveChanged(it) },
-        modifier = modifier.padding(horizontal = animatePadding),
-        placeholder = { Text(stringResource(id = HomeR.string.placeholder_searchbar)) },
-        leadingIcon = {
-            if (isSearchActive) {
-                IconButton(
-                    onClick = {
-                        onActiveChanged(false)
-                    },
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                }
-            } else {
-                Icon(
-                    imageVector = Icons.Rounded.Search,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        },
-        trailingIcon =
-        if (isSearchActive && query.isNotEmpty()) {
-            {
-                IconButton(
-                    onClick = {
-                        onQueryChange("")
-                        onSearchItemReset()
-                    },
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.Close,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                }
-            }
-        } else {
-            null
-        },
-        colors =
-        SearchBarDefaults.colors(
-            containerColor =
-            if (isSearchActive) {
-                MaterialTheme.colorScheme.background
-            } else {
-                MaterialTheme.colorScheme.surfaceContainerLow
-            },
-        ),
-        tonalElevation = 0.dp,
+        expanded = isSearchActive,
+        onExpandedChange = onActiveChanged,
+        windowInsets = if (isSearchActive) WindowInsets(0, 0, 0, 0) else SearchBarDefaults.windowInsets,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = animatePadding),
     ) {
         Box(
             modifier =
-            modifier
-                .fillMaxSize()
-                .padding(horizontal = 12.dp),
+                Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 12.dp)
+                    .navigationBarsPadding()
+                    .imePadding(),
         ) {
             if (user != null) {
                 SearchResultItem(
                     user = user,
                     onClick = moveToDetail,
-                    modifier =
-                    Modifier
-                        .align(
-                            Alignment.TopStart,
-                        ).padding(top = 20.dp),
+                    modifier = Modifier
+                        .padding(top = 20.dp)
+                        .align(Alignment.TopCenter),
                 )
             }
             if (loading) {
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             }
+            Button(
+                onClick = { onSearch(query) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+            ) {
+                Text("검색하세요")
+            }
         }
     }
+
 }
 
 @Composable
@@ -336,9 +316,9 @@ private fun SearchItemList(
 ) {
     LazyColumn(
         modifier =
-        modifier
-            .fillMaxSize()
-            .padding(vertical = 12.dp),
+            modifier
+                .fillMaxSize()
+                .padding(vertical = 12.dp),
     ) {
         items(
             users.itemCount,
@@ -359,30 +339,30 @@ private fun HomeItem(
 ) {
     Row(
         modifier =
-        modifier
-            .fillMaxWidth()
-            .heightIn(min = 80.dp, max = 100.dp)
-            .clickable(onClick = onClick)
-            .padding(12.dp),
+            modifier
+                .fillMaxWidth()
+                .heightIn(min = 80.dp, max = 100.dp)
+                .clickable(onClick = onClick)
+                .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         GlideImage(
             imageModel = { user.avatar },
             modifier =
-            Modifier
-                .padding(horizontal = 8.dp)
-                .sizeIn(minWidth = 20.dp, minHeight = 20.dp, maxWidth = 80.dp, maxHeight = 80.dp)
-                .clip(CircleShape),
+                Modifier
+                    .padding(horizontal = 8.dp)
+                    .sizeIn(minWidth = 20.dp, minHeight = 20.dp, maxWidth = 80.dp, maxHeight = 80.dp)
+                    .clip(CircleShape),
             component =
-            rememberImageComponent {
-                +ShimmerPlugin(
-                    Shimmer.Flash(
-                        baseColor = Color.White,
-                        highlightColor = Color.LightGray,
-                    ),
-                )
-            },
+                rememberImageComponent {
+                    +ShimmerPlugin(
+                        Shimmer.Flash(
+                            baseColor = Color.White,
+                            highlightColor = Color.LightGray,
+                        ),
+                    )
+                },
         )
         Text(
             text = user.login,
@@ -399,31 +379,31 @@ private fun SearchResultItem(
 ) {
     Row(
         modifier =
-        modifier
-            .fillMaxWidth()
-            .heightIn(min = 80.dp)
-            .clickable(onClick = onClick),
+            modifier
+                .fillMaxWidth()
+                .heightIn(min = 80.dp)
+                .clickable(onClick = onClick),
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         GlideImage(
             imageModel = { user.avatar },
             modifier =
-            Modifier
-                .padding(horizontal = 8.dp)
-                .size(80.dp)
-                .clip(
-                    CircleShape,
-                ),
-            component =
-            rememberImageComponent {
-                +ShimmerPlugin(
-                    Shimmer.Flash(
-                        baseColor = Color.White,
-                        highlightColor = Color.LightGray,
+                Modifier
+                    .padding(horizontal = 8.dp)
+                    .size(80.dp)
+                    .clip(
+                        CircleShape,
                     ),
-                )
-            },
+            component =
+                rememberImageComponent {
+                    +ShimmerPlugin(
+                        Shimmer.Flash(
+                            baseColor = Color.White,
+                            highlightColor = Color.LightGray,
+                        ),
+                    )
+                },
         )
 
         Column(modifier = Modifier.align(Alignment.CenterVertically)) {

--- a/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeScreen.kt
@@ -95,7 +95,7 @@ fun HomeScreen(
                 }
             snackBarHostState.showSnackbar(
                 message = message,
-                duration = SnackbarDuration.Short
+                duration = SnackbarDuration.Short,
             )
         }
     }
@@ -106,14 +106,14 @@ fun HomeScreen(
                 SearchStatus.NO_SUCH_USER -> {
                     snackBarHostState.showSnackbar(
                         message = noSuchUserMessage,
-                        duration = SnackbarDuration.Short
+                        duration = SnackbarDuration.Short,
                     )
                 }
 
                 SearchStatus.BAD_NETWORK -> {
                     snackBarHostState.showSnackbar(
                         message = httpException,
-                        duration = SnackbarDuration.Short
+                        duration = SnackbarDuration.Short,
                     )
                 }
 
@@ -159,9 +159,9 @@ fun HomeScreen(
             if (users.itemCount > 0) {
                 SearchItemList(
                     modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(paddingValues),
+                    Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues),
                     users = users,
                     onClick = { moveToDetail(it) },
                 )
@@ -276,11 +276,11 @@ private fun EmbeddedSearchBar(
     ) {
         Box(
             modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 12.dp)
-                    .navigationBarsPadding()
-                    .imePadding(),
+            Modifier
+                .fillMaxSize()
+                .padding(horizontal = 12.dp)
+                .navigationBarsPadding()
+                .imePadding(),
         ) {
             if (user != null) {
                 SearchResultItem(
@@ -298,13 +298,12 @@ private fun EmbeddedSearchBar(
                 onClick = { onSearch(query) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .align(Alignment.BottomCenter)
+                    .align(Alignment.BottomCenter),
             ) {
                 Text("검색하세요")
             }
         }
     }
-
 }
 
 @Composable
@@ -315,9 +314,9 @@ private fun SearchItemList(
 ) {
     LazyColumn(
         modifier =
-            modifier
-                .fillMaxSize()
-                .padding(vertical = 12.dp),
+        modifier
+            .fillMaxSize()
+            .padding(vertical = 12.dp),
     ) {
         items(
             users.itemCount,
@@ -338,30 +337,30 @@ private fun HomeItem(
 ) {
     Row(
         modifier =
-            modifier
-                .fillMaxWidth()
-                .heightIn(min = 80.dp, max = 100.dp)
-                .clickable(onClick = onClick)
-                .padding(12.dp),
+        modifier
+            .fillMaxWidth()
+            .heightIn(min = 80.dp, max = 100.dp)
+            .clickable(onClick = onClick)
+            .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         GlideImage(
             imageModel = { user.avatar },
             modifier =
-                Modifier
-                    .padding(horizontal = 8.dp)
-                    .sizeIn(minWidth = 20.dp, minHeight = 20.dp, maxWidth = 80.dp, maxHeight = 80.dp)
-                    .clip(CircleShape),
+            Modifier
+                .padding(horizontal = 8.dp)
+                .sizeIn(minWidth = 20.dp, minHeight = 20.dp, maxWidth = 80.dp, maxHeight = 80.dp)
+                .clip(CircleShape),
             component =
-                rememberImageComponent {
-                    +ShimmerPlugin(
-                        Shimmer.Flash(
-                            baseColor = Color.White,
-                            highlightColor = Color.LightGray,
-                        ),
-                    )
-                },
+            rememberImageComponent {
+                +ShimmerPlugin(
+                    Shimmer.Flash(
+                        baseColor = Color.White,
+                        highlightColor = Color.LightGray,
+                    ),
+                )
+            },
         )
         Text(
             text = user.login,
@@ -378,31 +377,31 @@ private fun SearchResultItem(
 ) {
     Row(
         modifier =
-            modifier
-                .fillMaxWidth()
-                .heightIn(min = 80.dp)
-                .clickable(onClick = onClick),
+        modifier
+            .fillMaxWidth()
+            .heightIn(min = 80.dp)
+            .clickable(onClick = onClick),
         verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         GlideImage(
             imageModel = { user.avatar },
             modifier =
-                Modifier
-                    .padding(horizontal = 8.dp)
-                    .size(80.dp)
-                    .clip(
-                        CircleShape,
-                    ),
+            Modifier
+                .padding(horizontal = 8.dp)
+                .size(80.dp)
+                .clip(
+                    CircleShape,
+                ),
             component =
-                rememberImageComponent {
-                    +ShimmerPlugin(
-                        Shimmer.Flash(
-                            baseColor = Color.White,
-                            highlightColor = Color.LightGray,
-                        ),
-                    )
-                },
+            rememberImageComponent {
+                +ShimmerPlugin(
+                    Shimmer.Flash(
+                        baseColor = Color.White,
+                        highlightColor = Color.LightGray,
+                    ),
+                )
+            },
         )
 
         Column(modifier = Modifier.align(Alignment.CenterVertically)) {

--- a/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp

--- a/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeUiState.kt
+++ b/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeUiState.kt
@@ -3,12 +3,12 @@ package com.gyleedev.githubsearch.feature.home
 import com.gyleedev.githubsearch.domain.model.UserModel
 
 sealed interface HomeUiState {
-    data object Loading: HomeUiState
+    data object Loading : HomeUiState
 
     data class Success(
         val searchQuery: String,
         val searchedUser: UserModel?,
         val isLoading: Boolean,
 
-        ): HomeUiState
+    ) : HomeUiState
 }

--- a/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeUiState.kt
+++ b/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeUiState.kt
@@ -1,0 +1,14 @@
+package com.gyleedev.githubsearch.feature.home
+
+import com.gyleedev.githubsearch.domain.model.UserModel
+
+sealed interface HomeUiState {
+    data object Loading: HomeUiState
+
+    data class Success(
+        val searchQuery: String,
+        val searchedUser: UserModel?,
+        val isLoading: Boolean,
+
+        ): HomeUiState
+}

--- a/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeViewModel.kt
@@ -7,17 +7,31 @@ import androidx.paging.cachedIn
 import com.gyleedev.githubsearch.core.common.BaseViewModel
 import com.gyleedev.githubsearch.domain.model.SearchStatus
 import com.gyleedev.githubsearch.domain.model.UserModel
-import com.gyleedev.githubsearch.domain.model.UserWrapper
+import com.gyleedev.githubsearch.domain.model.UserSearchResult
 import com.gyleedev.githubsearch.domain.usecase.GetUsersUseCase
 import com.gyleedev.githubsearch.domain.usecase.SearchUserUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+/*
+   홈 문제점 개편안
+   1. stability 해결
+   2. searchbar deprecate 된거 말고 m3 expressive 로 수정
+   3. 기능 수정
+    3-1. 서치바 debounce 걸어서 검색어 넣었을 때 결과물 있으면 결과 물 넣어.
+    3-2. 웹 찔러서 결과물 받아왔으면 repo 정보 상관 없이 일단 넣어. repo는 detail 에서
+    3-3. 검색 버튼을 넣던가 뭐 해야지 엔터로만 검색이 웬말?
+    3-4. 뭔가 보여주는 정보를 추가해
+    3-5. baseviewmodel의 에러처리법 보고 에러 처리법 다시 익혀. 저거 왜쓰나 몰라
+    3-6. 홈에 정렬을 넣던가 해야할듯
+ */
 @HiltViewModel
 class HomeViewModel
 @Inject
@@ -25,14 +39,9 @@ constructor(
     getUsersUseCase: GetUsersUseCase,
     private val searchUserUseCase: SearchUserUseCase,
 ) : BaseViewModel() {
-    private val _searchQuery = MutableStateFlow("")
-    val searchQuery: StateFlow<String> = _searchQuery
-
-    private val _userInfo = MutableStateFlow<UserModel?>(null)
-    val userInfo: StateFlow<UserModel?> = _userInfo
-
-    private val _loading = MutableStateFlow(false)
-    val loading: StateFlow<Boolean> = _loading
+    private val searchQuery = MutableStateFlow("")
+    private val searchedUser = MutableStateFlow<UserModel?>(null)
+    private val isLoading = MutableStateFlow(false)
 
     val users = getUsersUseCase().cachedIn(viewModelScope)
 
@@ -42,56 +51,61 @@ constructor(
     private val _requestAuthentication = MutableSharedFlow<Unit>()
     val requestAuthentication: SharedFlow<Unit> = _requestAuthentication
 
+    val uiState = combine(searchQuery, searchedUser, isLoading) { query, user, isLoading ->
+        HomeUiState.Success(
+            searchQuery = query,
+            searchedUser = user,
+            isLoading = isLoading
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+        initialValue = HomeUiState.Loading,
+    )
+
     @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
     fun getUser(id: String) {
         viewModelScope.launch(exceptionHandler) {
-            when (val userWrapper = searchUserUseCase(id)) {
-                is UserWrapper.FromDatabase -> {
-                    _userInfo.emit(userWrapper.data)
+            isLoading.emit(true)
+            val result = searchUserUseCase(id)
+            when (result) {
+                is UserSearchResult.FromDatabase -> {
+                    searchedUser.emit(result.data)
                 }
 
-                is UserWrapper.Success -> {
-                    _userInfo.emit(userWrapper.data)
+                is UserSearchResult.Success -> {
+                    searchedUser.emit(result.data)
                 }
 
-                is UserWrapper.Failure -> {
-                    alertResponseFail(userWrapper)
+                is UserSearchResult.Failure -> {
+                    alertResponseFail(result.status)
                 }
             }
-            _loading.emit(false)
+            isLoading.emit(false)
         }
     }
 
-    private suspend fun alertResponseFail(userWrapper: UserWrapper) {
-        val wrapper = userWrapper as UserWrapper.Failure
-        when (wrapper.status) {
+    private suspend fun alertResponseFail(status: SearchStatus) {
+        when (status) {
             SearchStatus.NEED_AUTHENTICATION -> {
                 _requestAuthentication.emit(Unit)
             }
 
             else -> {
-                _errorAlert.emit(wrapper.status)
+                _errorAlert.emit(status)
             }
         }
     }
 
-    suspend fun changeLoadingState() {
-        _loading.emit(!_loading.value)
-    }
-
-    suspend fun stopLoading() {
-        _loading.emit(false)
-    }
-
     fun updateSearchId(id: String) {
         viewModelScope.launch {
-            _searchQuery.emit(id)
+            searchQuery.emit(id)
         }
     }
 
-    fun resetUser() {
+    fun resetQuery() {
         viewModelScope.launch {
-            _userInfo.emit(null)
+            searchedUser.emit(null)
         }
     }
 }

--- a/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeViewModel.kt
@@ -21,16 +21,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /*
-   홈 문제점 개편안
-   1. stability 해결
-   2. searchbar deprecate 된거 말고 m3 expressive 로 수정
-   3. 기능 수정
-    3-1. 서치바 debounce 걸어서 검색어 넣었을 때 결과물 있으면 결과 물 넣어.
-    3-2. 웹 찔러서 결과물 받아왔으면 repo 정보 상관 없이 일단 넣어. repo는 detail 에서
-    3-3. 검색 버튼을 넣던가 뭐 해야지 엔터로만 검색이 웬말?
-    3-4. 뭔가 보여주는 정보를 추가해
-    3-5. baseviewmodel의 에러처리법 보고 에러 처리법 다시 익혀. 저거 왜쓰나 몰라
-    3-6. 홈에 정렬을 넣던가 해야할듯
+    3-5. baseviewmodel의 에러처리법 보고 에러처리 개선안 고안
  */
 @HiltViewModel
 class HomeViewModel
@@ -55,7 +46,7 @@ constructor(
         HomeUiState.Success(
             searchQuery = query,
             searchedUser = user,
-            isLoading = isLoading
+            isLoading = isLoading,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -14,3 +14,4 @@ dependencies {
     implementation(libs.appcompat)
     implementation(libs.androidx.material.icons)
 }
+composeCompiler { reportsDestination = layout.buildDirectory.dir("compose_reports") }


### PR DESCRIPTION
요약 :  
- 앱의 메인 진입점인 HomeScreen과 하단 네비게이션의 UI를 최신 Material 3 컴포넌트로 마이그레이션, 
- Window Insets(시스템 여백) 꼬임 현상을 바로잡는 리팩터링. 
- HomeViewModel의 개별 상태들을 HomeUiState로 통합하여 단방향 데이터 흐름(UDF)을 강화하고 불필요한 레거시 코드를 제거

  🚀 주요 변경 사항

  1. 🏗️ 상태 관리 및 도메인 모델 개선 (Architecture)
   * HomeUiState 도입: HomeViewModel 내에 파편화되어 있던 searchQuery, userInfo, loading 상태를 uiState(StateFlow<HomeUiState>) 하나로 통합하여 화면 상태의 일관성을 확보
   * 명칭 리팩터링: 기존의 모호했던 UserWrapper를 데이터의 목적성을 더 명확히 드러내는 UserSearchResult로 변경, 이를 참조하는 모든 UseCase를  업데이트

  2. 🎨 Material 3 마이그레이션 (UI/UX)
   * 하단 네비게이션 겹침 문제 해결: GithubSearchScreen의 구형 BottomNavigation(M2)을 NavigationBar(M3)로 교체하여, 별도의 패딩 없이도 시스템 바와 자연스럽게 어우러지도록 개선
   * SearchBar 업데이트: HomeScreen의 검색 바를 최신 M3 SearchBarDefaults.InputField API로 마이그레이션
   * 오류 피드백 개선: 네트워크 및 검색 실패 에러 알림을 기존의 Toast에서 Snackbar로 변경하여 사용자 경험을 향상

  3. 📐 Window Insets(여백) 최적화
   * 최상위 Scaffold가 일괄적으로 주입하던 Inset 여백을 무시(contentWindowInsets = WindowInsets(0, 0, 0, 0))하도록 수정
   * 대신 HomeScreen의 SearchBar와 검색 결과 내부 영역에서 imePadding(), navigationBarsPadding() 등을 명시적으로 선언하여 중복 패딩 발생과 화면 겹침 현상을 근본적으로 해결

  4. 🧹 리소스 정리 및 기타 (Chore)
   * app/build.gradle.kts에서 더 이상 사용하지 않는 의존성(fragment, landscapist.glide 등)을 대거 제거
   * 불필요해진 GlideModule 클래스 및 미사용 import 구문을 정리
   * composeCompiler 리포트 생성을 위해 각 feature 모듈 빌드 스크립트에 reportsDestination 설정을 추가하여 안정성(Stability) 추적 기반을 마련