### PR TITLE
Refactor(App): MainActivity 리팩터링 및 Compose 이벤트 처리 이관

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(platform(libs.androidx.compose.bom))
     implementation(libs.navigation.compose)
-
+    implementation(libs.hilt.navigation.compose)
     implementation(libs.androidx.core.ktx)
     implementation(libs.appcompat)
 

--- a/app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt
@@ -16,12 +16,19 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -34,16 +41,33 @@ import com.gyleedev.githubsearch.feature.detail.DetailScreen
 import com.gyleedev.githubsearch.feature.favorite.FavoriteScreen
 import com.gyleedev.githubsearch.feature.home.HomeScreen
 import com.gyleedev.githubsearch.feature.setting.SettingScreen
+import kotlinx.coroutines.flow.collectLatest
 
 @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
 @Composable
 fun GithubSearchScreen(
     modifier: Modifier = Modifier,
+    viewModel: MainViewModel = hiltViewModel(),
     navController: NavHostController = rememberNavController(),
-    onAuthenticationRequest: () -> Unit,
 ) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val snackBarHostState = remember { SnackbarHostState() }
+    val loginSuccessMessage = stringResource(id = R.string.log_in_success_message)
+    val loginFailMessage = stringResource(id = R.string.log_in_fail_message)
+
+    LaunchedEffect(viewModel.alertLoginSuccess, lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.alertLoginSuccess.collectLatest { result ->
+                val message = if (result) loginSuccessMessage else loginFailMessage
+                snackBarHostState.showSnackbar(
+                    message = message,
+                    duration = SnackbarDuration.Short,
+                )
+            }
+        }
+    }
 
     Scaffold(
         bottomBar = {
@@ -77,7 +101,7 @@ fun GithubSearchScreen(
                 HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                     moveToDetail = { navController.navigate("${BottomNavItem.Detail.screenRoute}/$it") },
-                    requestAuthentication = { onAuthenticationRequest() },
+                    requestAuthentication = viewModel::requestGithubLogin,
                 )
             }
 
@@ -106,7 +130,7 @@ fun GithubSearchScreen(
 
             composable(BottomNavItem.Setting.screenRoute) {
                 SettingScreen(
-                    requestAuthentication = { onAuthenticationRequest() },
+                    requestAuthentication = viewModel::requestGithubLogin,
                     modifier = Modifier.fillMaxSize(),
                 )
             }

--- a/app/src/main/java/com/gyleedev/githubsearch/ui/MainActivity.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/MainActivity.kt
@@ -1,22 +1,20 @@
 package com.gyleedev.githubsearch.ui
 
-import android.content.Context
+import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
-import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.annotation.RequiresExtension
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.gyleedev.githubsearch.BuildConfig
 import com.gyleedev.githubsearch.R
 import com.gyleedev.githubsearch.core.designsystem.theme.GithubSearchTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,51 +32,53 @@ class MainActivity : AppCompatActivity() {
             GithubSearchTheme {
                 GithubSearchScreen(
                     onAuthenticationRequest = {
-                        login(this)
+                        viewModel.requestGithubLogin()
                     },
                 )
             }
         }
 
+        handleIntent(intent)
+
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                viewModel.alertLoginSuccess.collect {
-                    showLoginResult(it)
+                launch {
+                    viewModel.alertLoginSuccess.collect {
+                        showLoginResult(it)
+                    }
+                }
+
+                launch {
+                    viewModel.launchOAuthEvent.collect { url ->
+                        launchCustomTabs(url)
+                    }
                 }
             }
         }
     }
 
-    fun login(context: Context) {
-        val clientId = BuildConfig.CLIENT_ID
-        val loginUrl =
-            Uri
-                .Builder()
-                .scheme("https")
-                .authority("github.com")
-                .appendPath("login")
-                .appendPath("oauth")
-                .appendPath("authorize")
-                .appendQueryParameter("client_id", clientId)
-                .build()
-
-        val customTabsIntent = CustomTabsIntent.Builder().build()
-
-        // 아래 플래그를 적용하지 않으면 로그인이 이미 된 상태에서 열 때 앱이 죽음
-        customTabsIntent.intent.setFlags(FLAG_ACTIVITY_CLEAR_TOP)
-        customTabsIntent.launchUrl(context, loginUrl)
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleIntent(intent)
     }
 
-    override fun onResume() {
-        super.onResume()
-        // ViewModel에서 로그인한거 받아서 처리
-        intent?.data?.getQueryParameter("code")?.let {
-            if (it.isNotEmpty()) {
-                viewModel.getAccessToken(it)
+    private fun handleIntent(intent: Intent?) {
+        intent?.data?.getQueryParameter("code")?.let { code ->
+            if (code.isNotEmpty()) {
+                viewModel.getAccessToken(code)
             } else {
                 println("Error exists check your network status")
             }
+            // 처리 완료 후 Intent Data를 비워 onResume 등에서 중복 실행되는 것을 방지
+            intent.data = null
         }
+    }
+
+    private fun launchCustomTabs(url: String) {
+        val customTabsIntent = CustomTabsIntent.Builder().build()
+        customTabsIntent.intent.flags = FLAG_ACTIVITY_CLEAR_TOP
+        customTabsIntent.launchUrl(this, url.toUri())
     }
 
     private fun showLoginResult(result: Boolean) {
@@ -88,7 +88,6 @@ class MainActivity : AppCompatActivity() {
             } else {
                 getString(R.string.log_in_fail_message)
             }
-
         Toast
             .makeText(
                 this@MainActivity,

--- a/app/src/main/java/com/gyleedev/githubsearch/ui/MainActivity.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/MainActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
 import android.os.Build
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -15,7 +14,6 @@ import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.gyleedev.githubsearch.R
 import com.gyleedev.githubsearch.core.designsystem.theme.GithubSearchTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -30,11 +28,7 @@ class MainActivity : AppCompatActivity() {
         enableEdgeToEdge()
         setContent {
             GithubSearchTheme {
-                GithubSearchScreen(
-                    onAuthenticationRequest = {
-                        viewModel.requestGithubLogin()
-                    },
-                )
+                GithubSearchScreen()
             }
         }
 
@@ -42,12 +36,6 @@ class MainActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                launch {
-                    viewModel.alertLoginSuccess.collect {
-                        showLoginResult(it)
-                    }
-                }
-
                 launch {
                     viewModel.launchOAuthEvent.collect { url ->
                         launchCustomTabs(url)
@@ -79,20 +67,5 @@ class MainActivity : AppCompatActivity() {
         val customTabsIntent = CustomTabsIntent.Builder().build()
         customTabsIntent.intent.flags = FLAG_ACTIVITY_CLEAR_TOP
         customTabsIntent.launchUrl(this, url.toUri())
-    }
-
-    private fun showLoginResult(result: Boolean) {
-        val resultMessage =
-            if (result) {
-                getString(R.string.log_in_success_message)
-            } else {
-                getString(R.string.log_in_fail_message)
-            }
-        Toast
-            .makeText(
-                this@MainActivity,
-                resultMessage,
-                Toast.LENGTH_SHORT,
-            ).show()
     }
 }

--- a/app/src/main/java/com/gyleedev/githubsearch/ui/MainViewModel.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/MainViewModel.kt
@@ -1,6 +1,8 @@
 package com.gyleedev.githubsearch.ui
 
+import android.net.Uri
 import androidx.lifecycle.viewModelScope
+import com.gyleedev.githubsearch.BuildConfig
 import com.gyleedev.githubsearch.domain.usecase.GetAccessTokenUseCase
 import com.gyleedev.ui.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -20,10 +22,31 @@ class MainViewModel @Inject constructor(
     private val _alertLoginSuccess = MutableSharedFlow<Boolean>()
     val alertLoginSuccess: SharedFlow<Boolean> = _alertLoginSuccess
 
+    private val _launchOAuthEvent = MutableSharedFlow<String>()
+    val launchOAuthEvent: SharedFlow<String> = _launchOAuthEvent
+
     fun getAccessToken(code: String) {
         viewModelScope.launch {
             val result = getAccessTokenUseCase(code)
             _alertLoginSuccess.emit(result)
+        }
+    }
+
+    fun requestGithubLogin() {
+        val clientId = BuildConfig.CLIENT_ID
+        val loginUrl =
+            Uri.Builder()
+                .scheme("https")
+                .authority("github.com")
+                .appendPath("login")
+                .appendPath("oauth")
+                .appendPath("authorize")
+                .appendQueryParameter("client_id", clientId)
+                .build()
+                .toString()
+
+        viewModelScope.launch {
+            _launchOAuthEvent.emit(loginUrl)
         }
     }
 }


### PR DESCRIPTION
`MainActivity`에 집중되어 있던 UI 이벤트와 비즈니스 로직을 Compose 화면(Screen)과 ViewModel 레벨로 분리하여 **관심사 분리(Separation of Concerns)** 및 **단방향 데이터 흐름(UDF)**을 개선하기 위한 리팩터링입니다.
    
     ##  Changes
     ### App 모듈
     - **의존성 추가 (`Chore`)**
       - `libs.hilt.navigation.compose` 의존성을 추가하여 `GithubSearchScreen` 내에서 `hiltViewModel()`을 사용할 수 있도록 환경 구성.
     - **MainActivity 리팩터링 (`Refactor`)**
      - Activity 내부에 존재할 필요가 없는 로직들을 `MainViewModel`로 분리.
      - `handleIntent` 처리 후 `intent.data = null`을 대입하여 onResume 등에서 인텐트가 중복 실행되는 이슈 방지.
    - **GithubSearchScreen 이벤트 처리 이관 (`Refactor`)**
      - `MainActivity`에서 Hoisting으로 처리하던 로그인 요청 로직 제거.
      - 로그인 결과(성공/실패) 알림을 기존 Toast 방식에서 Compose의 `SnackbarHostState`를 활용한 Snackbar 방식으로 이관.
      - `LaunchedEffect`와 `repeatOnLifecycle(Lifecycle.State.STARTED)`를 적용하여 백그라운드 전환 시 안전한 이벤트 수집(collect) 구현.
   
close #105 