### PR TITLE
[Refactor] GitHub OAuth 인증 로직 결함 수정 및 데이터 계층 안정성 강화

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,7 @@ extensions.configure<ApplicationExtension>("android") {
         applicationId = "com.gyleedev.githubsearch"
         buildConfigField("String", "CLIENT_ID", "\"${getApiKey("CLIENT_ID")}\"")
         buildConfigField("String", "CLIENT_SECRET", "\"${getApiKey("CLIENT_SECRET")}\"")
+        buildConfigField("String", "REDIRECT_URI", "\"${getApiKey("REDIRECT_URI")}\"")
     }
 
     buildFeatures {

--- a/app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt
@@ -1,7 +1,14 @@
 package com.gyleedev.githubsearch.ui
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Build
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresExtension
+import androidx.browser.auth.AuthTabIntent
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -25,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -42,6 +50,7 @@ import com.gyleedev.githubsearch.feature.favorite.FavoriteScreen
 import com.gyleedev.githubsearch.feature.home.HomeScreen
 import com.gyleedev.githubsearch.feature.setting.SettingScreen
 import kotlinx.coroutines.flow.collectLatest
+import com.gyleedev.githubsearch.BuildConfig as AppBuildConfig
 
 @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
 @Composable
@@ -56,6 +65,28 @@ fun GithubSearchScreen(
     val snackBarHostState = remember { SnackbarHostState() }
     val loginSuccessMessage = stringResource(id = R.string.log_in_success_message)
     val loginFailMessage = stringResource(id = R.string.log_in_fail_message)
+    val redirectUri = remember { AppBuildConfig.REDIRECT_URI }
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult(),
+    ) { result ->
+        println(result)
+        if (result.resultCode == Activity.RESULT_OK) {
+            val intent = result.data
+            if (intent != null) {
+                val resultUri = intent.data
+                if (resultUri != null) {
+                    val code = resultUri.getQueryParameter("code")
+                    // 최종적으로 코드를 추출하여 상태를 업데이트
+                    code?.let { code ->
+                        if (code.isNotBlank()) {
+                            viewModel.getAccessToken(code)
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     LaunchedEffect(viewModel.alertLoginSuccess, lifecycleOwner) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -64,6 +95,19 @@ fun GithubSearchScreen(
                 snackBarHostState.showSnackbar(
                     message = message,
                     duration = SnackbarDuration.Short,
+                )
+            }
+        }
+    }
+
+    LaunchedEffect(viewModel.launchOAuthEvent, lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.launchOAuthEvent.collectLatest { loginUri ->
+                println(loginUri)
+                launchAuthTab(
+                    launcher = launcher,
+                    loginUri = loginUri,
+                    redirectUri = redirectUri,
                 )
             }
         }
@@ -168,6 +212,20 @@ fun BottomNavigation(
             )
         }
     }
+}
+
+private fun launchAuthTab(
+    launcher: ManagedActivityResultLauncher<Intent, ActivityResult>,
+    loginUri: String,
+    redirectUri: String,
+) {
+    val authTabIntent = AuthTabIntent.Builder().build()
+    val scheme = redirectUri.toUri().scheme ?: ""
+    authTabIntent.launch(
+        launcher,
+        loginUri.toUri(),
+        scheme,
+    )
 }
 
 sealed class BottomNavItem(

--- a/app/src/main/java/com/gyleedev/githubsearch/ui/MainActivity.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/MainActivity.kt
@@ -1,27 +1,16 @@
 package com.gyleedev.githubsearch.ui
 
-import android.content.Intent
-import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.activity.viewModels
 import androidx.annotation.RequiresExtension
 import androidx.appcompat.app.AppCompatActivity
-import androidx.browser.customtabs.CustomTabsIntent
-import androidx.core.net.toUri
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.gyleedev.githubsearch.core.designsystem.theme.GithubSearchTheme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
-    private val viewModel by viewModels<MainViewModel>()
-
     @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,41 +20,5 @@ class MainActivity : AppCompatActivity() {
                 GithubSearchScreen()
             }
         }
-
-        handleIntent(intent)
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                launch {
-                    viewModel.launchOAuthEvent.collect { url ->
-                        launchCustomTabs(url)
-                    }
-                }
-            }
-        }
-    }
-
-    override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
-        setIntent(intent)
-        handleIntent(intent)
-    }
-
-    private fun handleIntent(intent: Intent?) {
-        intent?.data?.getQueryParameter("code")?.let { code ->
-            if (code.isNotEmpty()) {
-                viewModel.getAccessToken(code)
-            } else {
-                println("Error exists check your network status")
-            }
-            // 처리 완료 후 Intent Data를 비워 onResume 등에서 중복 실행되는 것을 방지
-            intent.data = null
-        }
-    }
-
-    private fun launchCustomTabs(url: String) {
-        val customTabsIntent = CustomTabsIntent.Builder().build()
-        customTabsIntent.intent.flags = FLAG_ACTIVITY_CLEAR_TOP
-        customTabsIntent.launchUrl(this, url.toUri())
     }
 }

--- a/data/src/main/java/com/gyleedev/data/remote/RevokeService.kt
+++ b/data/src/main/java/com/gyleedev/data/remote/RevokeService.kt
@@ -1,7 +1,6 @@
 package com.gyleedev.data.remote
 
 import com.gyleedev.data.remote.request.RevokeRequest
-import com.gyleedev.data.remote.response.RevokeResponse
 import retrofit2.http.Body
 import retrofit2.http.HTTP
 import retrofit2.http.Path
@@ -11,5 +10,5 @@ interface RevokeService {
     suspend fun revoke(
         @Path("client_id") clientId: String,
         @Body accessToken: RevokeRequest,
-    ): RevokeResponse
+    ): Unit
 }

--- a/data/src/main/java/com/gyleedev/data/repository/GitHubRepositoryImpl.kt
+++ b/data/src/main/java/com/gyleedev/data/repository/GitHubRepositoryImpl.kt
@@ -167,16 +167,27 @@ class GitHubRepositoryImpl @Inject constructor(
 
     // Main
     override suspend fun getAccessToken(code: String): GithubAccessModel? {
-        val response =
-            accessService.getAccessToken(
-                clientId = BuildConfig.CLIENT_ID,
-                clientSecret = BuildConfig.CLIENT_SECRET,
-                code = code,
-            )
-        return if (response.isSuccessful && response.code() == 200) {
-            response.body()?.let { GithubAccessModel(it.accessToken) }
-        } else {
-            null
+        try {
+            val response =
+                accessService.getAccessToken(
+                    clientId = BuildConfig.CLIENT_ID,
+                    clientSecret = BuildConfig.CLIENT_SECRET,
+                    code = code,
+                )
+
+            if (response.isSuccessful && response.code() == 200) {
+                val body = response.body()
+
+                if (body != null) {
+                    val accessToken = body.accessToken
+
+                    return GithubAccessModel(accessToken = accessToken)
+                }
+            }
+
+            return null
+        } catch (e: Exception) {
+            return null
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
  변경 사항 요약 (Summary)
  GitHub OAuth 인증 과정에서 발생하던 bad_verification_code 오류를 해결하고, 데이터 계층의 예외 처리 로직을 보완하여 앱의 전반적인 안정성을 향상시켰습니다.

  ---

  🛠 상세 변경 내역 (Key Changes)

  1. GitHub OAuth 인증 로직 수정 및 안정성 확보 (data 모듈)
   * 중복 토큰 요청 결함 수정: saveAccessToken 호출 시 이미 소모된 인증 코드로 다시 토큰을 요청하던 로직을 제거하여 bad_verification_code 오류를 근본적으로 해결했습니다.
   * 네트워크 예외 처리 추가: getAccessToken 함수를 try-catch 블록으로 감싸 네트워크 오류나 런타임 예외 발생 시 앱이 크래시되지 않도록 방어 로직을 구축했습니다.

  2. 앱 아키텍처 정돈
   * MainActivity 경량화: CustomTab 관련 로직과 MainViewModel 의존성을 제거하고, GithubSearchScreen으로 인증 책임을 이관하여 관심사를 분리했습니다.
   * API 서비스 최적화: RevokeService의 반환 타입을 불필요한 경우 제거하여 명확성을 확보했습니다.
     
close #111 