### PR TITLE
 [Refactor] Favorite 화면 리팩터링 및 Home UI 정렬 수정

### DIFF
--- a/app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt
@@ -70,7 +70,6 @@ fun GithubSearchScreen(
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult(),
     ) { result ->
-        println(result)
         if (result.resultCode == Activity.RESULT_OK) {
             val intent = result.data
             if (intent != null) {
@@ -103,7 +102,6 @@ fun GithubSearchScreen(
     LaunchedEffect(viewModel.launchOAuthEvent, lifecycleOwner) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             viewModel.launchOAuthEvent.collectLatest { loginUri ->
-                println(loginUri)
                 launchAuthTab(
                     launcher = launcher,
                     loginUri = loginUri,

--- a/feature/favorite/src/main/java/com/gyleedev/githubsearch/feature/favorite/FavoriteScreen.kt
+++ b/feature/favorite/src/main/java/com/gyleedev/githubsearch/feature/favorite/FavoriteScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -19,11 +18,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -49,97 +47,104 @@ fun FavoriteScreen(
     viewModel: FavoriteViewModel = hiltViewModel(),
 ) {
     val users = viewModel.items.collectAsLazyPagingItems()
-    val selectedFilter by viewModel.filterState.collectAsStateWithLifecycle()
-    val showDeleteDialog = remember { mutableStateOf(false) }
-    val showFilterDialog = remember { mutableStateOf(false) }
-    // TODO 이걸 왜 focus 하는지 확인하고 로직 바꿀 것.
-    val user = remember { mutableStateOf<UserModel?>(null) }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text(text = stringResource(id = FavoriteR.string.title_favorite)) },
-                actions = {
-                    IconButton(onClick = { showFilterDialog.value = !showFilterDialog.value }) {
-                        Icon(
-                            imageVector = Icons.Filled.FilterList,
-                            contentDescription = stringResource(id = FavoriteR.string.icon_content_description_filter),
-                        )
-                    }
-                },
-                modifier = Modifier,
-            )
-        },
+        topBar = { FavoriteTopAppBar(onClick = viewModel::updateShowFilterDialog) },
         modifier = modifier.fillMaxSize(),
     ) { paddingValues ->
-        if (users.itemCount > 0) {
-            FavoriteItemList(
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(paddingValues),
+        if (uiState is FavoriteUiState.Success) {
+            val state = uiState as FavoriteUiState.Success
+            FavoriteScreen(
                 users = users,
-                onClick = { moveToDetail(it) },
-                onLongClick = {
-                    user.value = it
-                    showDeleteDialog.value = true
-                },
-            )
-        } else {
-            NoItem(
+                filterStatus = state.filterState,
+                onFilterDismiss = viewModel::updateShowFilterDialog,
+                onFilterClick = viewModel::updateFilter,
+                onFavoriteDelete = viewModel::updateFavoriteStatus,
+                onDeleteCancel = viewModel::updateShowFavoriteDialog,
+                onItemClick = moveToDetail,
+                onItemLongClick = viewModel::showFavoriteDialog,
+                showFavoriteDialog = state.favoriteDialogState,
+                showFilterDialog = state.filterDialogState,
                 modifier = Modifier.padding(paddingValues),
             )
         }
     }
+}
 
-    if (showDeleteDialog.value) {
-        AlertDialog(
-            onDismissRequest = { showDeleteDialog.value = false },
-            title = { Text(text = stringResource(id = FavoriteR.string.text_delete_favorite_title)) },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        showDeleteDialog.value = false
-                        user.value?.let { viewModel.updateFavoriteStatus(it) }
-                    },
-                ) {
-                    Text(stringResource(id = DesignSystemR.string.text_dialog_confirm))
-                }
-            },
-            dismissButton = {
-                Button(
-                    onClick = {
-                        showDeleteDialog.value = false
-                        user.value = null
-                    },
-                ) {
-                    Text(stringResource(id = DesignSystemR.string.text_dialog_cancel))
-                }
-            },
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun FavoriteScreen(
+    users: LazyPagingItems<UserModel>,
+    filterStatus: FilterStatus,
+    onFilterDismiss: () -> Unit,
+    onFilterClick: (FilterStatus) -> Unit,
+    onFavoriteDelete: () -> Unit,
+    onDeleteCancel: () -> Unit,
+    onItemClick: (String) -> Unit,
+    onItemLongClick: (UserModel) -> Unit,
+    showFavoriteDialog: Boolean,
+    showFilterDialog: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    if (users.itemCount > 0) {
+        FavoriteItemList(
+            modifier = modifier.fillMaxSize(),
+            users = users,
+            onClick = onItemClick,
+            onLongClick = onItemLongClick,
         )
+    } else {
+        NoItem(modifier = modifier)
     }
 
-    if (showFilterDialog.value) {
+    if (showFavoriteDialog) {
+        DeleteFavoriteDialog(
+            onConfirm = onFavoriteDelete,
+            onDismiss = onDeleteCancel,
+        )
+    }
+    if (showFilterDialog) {
         FilterDialog(
-            onChangeState = { showFilterDialog.value = it },
-            selectedFilter = selectedFilter,
-            onSelectedItemChange = viewModel::updateFilter,
+            onDismiss = onFilterDismiss,
+            selectedFilter = filterStatus,
+            onSelectedItemChange = onFilterClick,
         )
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun FavoriteTopAppBar(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    TopAppBar(
+        title = { Text(text = stringResource(id = FavoriteR.string.title_favorite)) },
+        actions = {
+            IconButton(onClick = onClick) {
+                Icon(
+                    imageVector = Icons.Filled.FilterList,
+                    contentDescription = stringResource(id = FavoriteR.string.icon_content_description_filter),
+                )
+            }
+        },
+        modifier = modifier,
+    )
 }
 
 @Composable
 private fun FavoriteItemList(
     users: LazyPagingItems<UserModel>,
-    modifier: Modifier = Modifier,
     onClick: (String) -> Unit,
     onLongClick: (UserModel) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     LazyColumn(
         modifier =
-        modifier
-            .fillMaxSize()
-            .padding(vertical = 12.dp),
+            modifier
+                .fillMaxSize()
+                .padding(vertical = 12.dp),
     ) {
         items(
             users.itemCount,
@@ -175,14 +180,41 @@ private fun NoItem(modifier: Modifier) {
 }
 
 @Composable
+fun DeleteFavoriteDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(id = FavoriteR.string.text_delete_favorite_title)) },
+        confirmButton = {
+            TextButton(
+                onClick = onConfirm,
+            ) {
+                Text(stringResource(id = DesignSystemR.string.text_dialog_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+            ) {
+                Text(stringResource(id = DesignSystemR.string.text_dialog_cancel))
+            }
+        },
+        modifier = modifier,
+    )
+}
+
+@Composable
 fun FilterDialog(
     selectedFilter: FilterStatus,
-    onChangeState: (Boolean) -> Unit,
+    onDismiss: () -> Unit,
     onSelectedItemChange: (FilterStatus) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AlertDialog(
-        onDismissRequest = { onChangeState(false) },
+        onDismissRequest = onDismiss,
         title = {
             Text(
                 text = stringResource(id = DesignSystemR.string.text_filter_title),
@@ -194,13 +226,13 @@ fun FilterDialog(
             Column {
                 Row(
                     modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .selectable(
-                            selected = selectedFilter == FilterStatus.ALL,
-                            onClick = { onSelectedItemChange(FilterStatus.ALL) },
-                            role = Role.RadioButton,
-                        ),
+                        Modifier
+                            .fillMaxWidth()
+                            .selectable(
+                                selected = selectedFilter == FilterStatus.ALL,
+                                onClick = { onSelectedItemChange(FilterStatus.ALL) },
+                                role = Role.RadioButton,
+                            ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     RadioButton(
@@ -212,13 +244,13 @@ fun FilterDialog(
                 }
                 Row(
                     modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .selectable(
-                            selected = selectedFilter == FilterStatus.REPO,
-                            onClick = { onSelectedItemChange(FilterStatus.REPO) },
-                            role = Role.RadioButton,
-                        ),
+                        Modifier
+                            .fillMaxWidth()
+                            .selectable(
+                                selected = selectedFilter == FilterStatus.REPO,
+                                onClick = { onSelectedItemChange(FilterStatus.REPO) },
+                                role = Role.RadioButton,
+                            ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     RadioButton(
@@ -230,13 +262,13 @@ fun FilterDialog(
                 }
                 Row(
                     modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .selectable(
-                            selected = selectedFilter == FilterStatus.NOREPO,
-                            onClick = { onSelectedItemChange(FilterStatus.NOREPO) },
-                            role = Role.RadioButton,
-                        ),
+                        Modifier
+                            .fillMaxWidth()
+                            .selectable(
+                                selected = selectedFilter == FilterStatus.NOREPO,
+                                onClick = { onSelectedItemChange(FilterStatus.NOREPO) },
+                                role = Role.RadioButton,
+                            ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     RadioButton(

--- a/feature/favorite/src/main/java/com/gyleedev/githubsearch/feature/favorite/FavoriteScreen.kt
+++ b/feature/favorite/src/main/java/com/gyleedev/githubsearch/feature/favorite/FavoriteScreen.kt
@@ -142,9 +142,9 @@ private fun FavoriteItemList(
 ) {
     LazyColumn(
         modifier =
-            modifier
-                .fillMaxSize()
-                .padding(vertical = 12.dp),
+        modifier
+            .fillMaxSize()
+            .padding(vertical = 12.dp),
     ) {
         items(
             users.itemCount,
@@ -226,13 +226,13 @@ fun FilterDialog(
             Column {
                 Row(
                     modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .selectable(
-                                selected = selectedFilter == FilterStatus.ALL,
-                                onClick = { onSelectedItemChange(FilterStatus.ALL) },
-                                role = Role.RadioButton,
-                            ),
+                    Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = selectedFilter == FilterStatus.ALL,
+                            onClick = { onSelectedItemChange(FilterStatus.ALL) },
+                            role = Role.RadioButton,
+                        ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     RadioButton(
@@ -244,13 +244,13 @@ fun FilterDialog(
                 }
                 Row(
                     modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .selectable(
-                                selected = selectedFilter == FilterStatus.REPO,
-                                onClick = { onSelectedItemChange(FilterStatus.REPO) },
-                                role = Role.RadioButton,
-                            ),
+                    Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = selectedFilter == FilterStatus.REPO,
+                            onClick = { onSelectedItemChange(FilterStatus.REPO) },
+                            role = Role.RadioButton,
+                        ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     RadioButton(
@@ -262,13 +262,13 @@ fun FilterDialog(
                 }
                 Row(
                     modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .selectable(
-                                selected = selectedFilter == FilterStatus.NOREPO,
-                                onClick = { onSelectedItemChange(FilterStatus.NOREPO) },
-                                role = Role.RadioButton,
-                            ),
+                    Modifier
+                        .fillMaxWidth()
+                        .selectable(
+                            selected = selectedFilter == FilterStatus.NOREPO,
+                            onClick = { onSelectedItemChange(FilterStatus.NOREPO) },
+                            role = Role.RadioButton,
+                        ),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     RadioButton(

--- a/feature/favorite/src/main/java/com/gyleedev/githubsearch/feature/favorite/FavoriteUiState.kt
+++ b/feature/favorite/src/main/java/com/gyleedev/githubsearch/feature/favorite/FavoriteUiState.kt
@@ -1,0 +1,12 @@
+package com.gyleedev.githubsearch.feature.favorite
+
+import com.gyleedev.githubsearch.domain.model.FilterStatus
+
+sealed interface FavoriteUiState {
+    data object Loading : FavoriteUiState
+    data class Success(
+        val favoriteDialogState: Boolean,
+        val filterDialogState: Boolean,
+        val filterState: FilterStatus,
+    ) : FavoriteUiState
+}

--- a/feature/favorite/src/main/java/com/gyleedev/githubsearch/feature/favorite/FavoriteViewModel.kt
+++ b/feature/favorite/src/main/java/com/gyleedev/githubsearch/feature/favorite/FavoriteViewModel.kt
@@ -10,8 +10,10 @@ import com.gyleedev.ui.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,25 +28,63 @@ class FavoriteViewModel @Inject constructor(
     private val updateFavoriteUseCase: UpdateFavoriteStatusUseCase,
     private val getFavoritesUseCase: GetFavoritesUseCase,
 ) : BaseViewModel() {
-    private val _filterState = MutableStateFlow(FilterStatus.ALL)
-    val filterState: StateFlow<FilterStatus> = _filterState
+    private val filterState = MutableStateFlow(FilterStatus.ALL)
+    private val showFavoriteDialog = MutableStateFlow(false)
+    private val showFilterDialog = MutableStateFlow(false)
+
+    private val focusedUser = MutableStateFlow<UserModel?>(null)
+
+    val uiState = combine(filterState, showFavoriteDialog, showFilterDialog) { filterState, showFavorite, showFilter ->
+        FavoriteUiState.Success(
+            favoriteDialogState = showFavorite,
+            filterDialogState = showFilter,
+            filterState = filterState,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = FavoriteUiState.Loading,
+    )
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val items =
-        _filterState
+        filterState
             .flatMapLatest {
                 getFavoritesUseCase(it)
             }.cachedIn(viewModelScope)
 
     fun updateFilter(status: FilterStatus) {
         viewModelScope.launch {
-            _filterState.emit(status)
+            filterState.emit(status)
         }
     }
 
-    fun updateFavoriteStatus(user: UserModel) {
+    fun showFavoriteDialog(user: UserModel) {
         viewModelScope.launch {
-            updateFavoriteUseCase(user)
+            focusedUser.emit(user)
+            updateShowFavoriteDialog()
+        }
+    }
+
+    fun updateFavoriteStatus() {
+        viewModelScope.launch {
+            focusedUser.value?.let {
+                updateFavoriteUseCase(it)
+            }
+            focusedUser.emit(null)
+            updateShowFavoriteDialog()
+        }
+    }
+
+    fun updateShowFavoriteDialog() {
+        viewModelScope.launch {
+            showFavoriteDialog.emit(!showFavoriteDialog.value)
+        }
+    }
+
+    fun updateShowFilterDialog() {
+        viewModelScope.launch {
+            showFilterDialog.emit(!showFilterDialog.value)
         }
     }
 }

--- a/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/gyleedev/githubsearch/feature/home/HomeScreen.kt
@@ -374,7 +374,7 @@ private fun SearchResultItem(
             .fillMaxWidth()
             .heightIn(min = 80.dp)
             .clickable(onClick = { onClick(login) }),
-        verticalAlignment = Alignment.Top,
+        verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         UserAvatar(avatar = avatar)


### PR DESCRIPTION
  1. 개요
   - 목적: 즐겨찾기(Favorite) 화면의 상태 관리 구조를 개선하여 유지보수성을 높이고, 홈 화면의 검색 결과 아이템 정렬 문제를 수정합니다.

  2. Changes

  feature:favorite
   - UI 상태 관리 최적화: FavoriteUiState 인터페이스를 도입하여 Loading 및 Success 상태를 명확히 구분하였습니다.
   - 상태 및 이벤트 호이스팅: FavoriteScreen 내부에 존재하던 다수의 상태(필터 다이얼로그 노출 여부, 즐겨찾기 삭제 다이얼로그 노출 여부 등)와 이벤트를 FavoriteViewModel로 호이스팅하여 비즈니스 로직과 UI를 분리하였습니다.
   - ViewModel 리팩터링: combine 연산자를 사용하여 필터 상태와 다이얼로그 노출 상태를 하나의 uiState로 통합 관리하도록 개선하였습니다.

  feature:home
   - UI 정렬 수정: HomeScreen.kt의 SearchResultItem 내 텍스트 및 이미지의 수직 정렬을 CenterVertically로 변경하여 시각적 일관성을 확보하였습니다.

  app
   - 코드 정리: GithubSearchScreen.kt에서 사용하지 않는 불필요한 로그 출력을 제거하였습니다.

 close #104 