### PR TITLE
[Feature/Refactor] 계정 권한 철회(Revoke) 기능 고도화 및 단위 테스트 추가

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,4 +44,4 @@ jobs:
         env:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-        run: ./gradlew spotlessCheck assembleDebug --parallel --build-cache --configure-on-demand
+        run: ./gradlew spotlessCheck assembleDebug testDebugUnitTest --parallel --build-cache --configure-on-demand

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,4 +11,6 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -13,4 +13,7 @@ dependencies {
     implementation(libs.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.fragment)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/data/src/main/java/com/gyleedev/data/remote/NetworkModule.kt
+++ b/data/src/main/java/com/gyleedev/data/remote/NetworkModule.kt
@@ -93,18 +93,13 @@ class NetworkModule {
     @TypeRevoke
     fun provideRevokeOkHttpClient(): OkHttpClient {
         val revokeInterceptor = RevokeInterceptor()
-        val interceptor =
-            if (BuildConfig.DEBUG) {
-                val loggingInterceptor = HttpLoggingInterceptor()
-                loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
-
-                OkHttpClient
-                    .Builder()
-                    .addNetworkInterceptor(loggingInterceptor)
-            } else {
-                OkHttpClient.Builder()
-            }
-        return interceptor.addInterceptor(revokeInterceptor).build()
+        val builder = OkHttpClient.Builder()
+        if (BuildConfig.DEBUG) {
+            val loggingInterceptor = HttpLoggingInterceptor()
+            loggingInterceptor.setLevel(HttpLoggingInterceptor.Level.BODY)
+            builder.addNetworkInterceptor(loggingInterceptor)
+        }
+        return builder.addInterceptor(revokeInterceptor).build()
     }
 
     @Singleton
@@ -112,8 +107,7 @@ class NetworkModule {
     @TypeRevoke
     fun provideRevokeRetrofit(
         @TypeRevoke okHttpClient: OkHttpClient,
-    ): Retrofit = Retrofit
-        .Builder()
+    ): Retrofit = Retrofit.Builder()
         .client(okHttpClient)
         .baseUrl(apiUrl)
         .addConverterFactory(GsonConverterFactory.create())

--- a/data/src/main/java/com/gyleedev/data/remote/RevokeInterceptor.kt
+++ b/data/src/main/java/com/gyleedev/data/remote/RevokeInterceptor.kt
@@ -3,19 +3,18 @@ package com.gyleedev.data.remote
 import com.gyleedev.data.BuildConfig
 import okhttp3.Interceptor
 import okhttp3.Response
-import java.util.Base64
 import javax.inject.Inject
 
 class RevokeInterceptor @Inject constructor() : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val encodedBasic: String =
-            Base64
-                .getEncoder()
-                .encodeToString(("${BuildConfig.CLIENT_ID}:${BuildConfig.CLIENT_SECRET}").toByteArray())
+        val encodedBasic = okhttp3.Credentials.basic(
+            BuildConfig.CLIENT_ID,
+            BuildConfig.CLIENT_SECRET,
+        )
         val builder = chain.request().newBuilder()
 
         builder.addHeader("Accept", "application/vnd.github+json")
-        builder.addHeader("Authorization", "Basic $encodedBasic")
+        builder.addHeader("Authorization", encodedBasic)
         return chain.proceed(builder.build())
     }
 }

--- a/data/src/main/java/com/gyleedev/data/remote/RevokeService.kt
+++ b/data/src/main/java/com/gyleedev/data/remote/RevokeService.kt
@@ -1,6 +1,7 @@
 package com.gyleedev.data.remote
 
 import com.gyleedev.data.remote.request.RevokeRequest
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.HTTP
 import retrofit2.http.Path
@@ -9,6 +10,6 @@ interface RevokeService {
     @HTTP(method = "DELETE", path = "applications/{client_id}/grant", hasBody = true)
     suspend fun revoke(
         @Path("client_id") clientId: String,
-        @Body accessToken: RevokeRequest,
-    ): Unit
+        @Body request: RevokeRequest,
+    ): Response<Unit>
 }

--- a/data/src/main/java/com/gyleedev/data/remote/request/RevokeRequest.kt
+++ b/data/src/main/java/com/gyleedev/data/remote/request/RevokeRequest.kt
@@ -1,13 +1,8 @@
 package com.gyleedev.data.remote.request
 
 import com.google.gson.annotations.SerializedName
-import com.gyleedev.githubsearch.domain.model.RevokeRequestBody
 
 data class RevokeRequest(
     @SerializedName("access_token")
     val accessToken: String,
-)
-
-fun RevokeRequestBody.toRequest(): RevokeRequest = RevokeRequest(
-    accessToken = accessToken,
 )

--- a/data/src/main/java/com/gyleedev/data/remote/response/RevokeResponse.kt
+++ b/data/src/main/java/com/gyleedev/data/remote/response/RevokeResponse.kt
@@ -1,7 +1,0 @@
-package com.gyleedev.data.remote.response
-
-import com.google.gson.annotations.SerializedName
-
-data class RevokeResponse(
-    @SerializedName("Status") val status: Int,
-)

--- a/data/src/main/java/com/gyleedev/data/repository/GitHubRepositoryImpl.kt
+++ b/data/src/main/java/com/gyleedev/data/repository/GitHubRepositoryImpl.kt
@@ -18,12 +18,12 @@ import com.gyleedev.data.remote.RevokeService
 import com.gyleedev.data.remote.TypeAccess
 import com.gyleedev.data.remote.TypeApi
 import com.gyleedev.data.remote.TypeRevoke
-import com.gyleedev.data.remote.request.toRequest
+import com.gyleedev.data.remote.request.RevokeRequest
 import com.gyleedev.data.remote.response.toModel
 import com.gyleedev.githubsearch.domain.model.FilterStatus
 import com.gyleedev.githubsearch.domain.model.GithubAccessModel
 import com.gyleedev.githubsearch.domain.model.RepositoryModel
-import com.gyleedev.githubsearch.domain.model.RevokeRequestBody
+import com.gyleedev.githubsearch.domain.model.RevokeResult
 import com.gyleedev.githubsearch.domain.model.UserModel
 import com.gyleedev.githubsearch.domain.repository.GitHubRepository
 import kotlinx.coroutines.flow.Flow
@@ -202,13 +202,19 @@ class GitHubRepositoryImpl @Inject constructor(
         reposDao.resetRepos()
     }
 
-    override suspend fun revokeApplication() {
+    override suspend fun revokeApplication(): RevokeResult {
         val accessToken = tokenPreference.getString()
-        if (accessToken.isNotEmpty() || accessToken.isNotBlank()) {
-            revokeService.revoke(
-                clientId = BuildConfig.CLIENT_ID,
-                accessToken = RevokeRequestBody(accessToken).toRequest(),
-            )
+        if (accessToken.isBlank()) {
+            return RevokeResult.NO_KEY
+        }
+        val response = revokeService.revoke(
+            clientId = BuildConfig.CLIENT_ID,
+            request = RevokeRequest(accessToken),
+        )
+        return if (response.isSuccessful) {
+            RevokeResult.SUCCESS
+        } else {
+            RevokeResult.FAIL
         }
     }
 

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -6,4 +6,7 @@ dependencies {
     api(libs.javax.inject)
     api(libs.paging.common)
     implementation(libs.kotlin.coroutines)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/model/RevokeRequestBody.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/model/RevokeRequestBody.kt
@@ -1,5 +1,0 @@
-package com.gyleedev.githubsearch.domain.model
-
-data class RevokeRequestBody(
-    val accessToken: String,
-)

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/model/RevokeResult.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/model/RevokeResult.kt
@@ -1,0 +1,7 @@
+package com.gyleedev.githubsearch.domain.model
+
+enum class RevokeResult {
+    SUCCESS,
+    NO_KEY,
+    FAIL,
+}

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/repository/GitHubRepository.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/repository/GitHubRepository.kt
@@ -5,6 +5,7 @@ import com.gyleedev.githubsearch.domain.model.AccessTime
 import com.gyleedev.githubsearch.domain.model.FilterStatus
 import com.gyleedev.githubsearch.domain.model.GithubAccessModel
 import com.gyleedev.githubsearch.domain.model.RepositoryModel
+import com.gyleedev.githubsearch.domain.model.RevokeResult
 import com.gyleedev.githubsearch.domain.model.UserModel
 import kotlinx.coroutines.flow.Flow
 
@@ -40,7 +41,7 @@ interface GitHubRepository {
 
     suspend fun resetData()
 
-    suspend fun revokeApplication()
+    suspend fun revokeApplication(): RevokeResult
 
     suspend fun saveAccessToken(token: String)
 

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/RevokeApplicationUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/RevokeApplicationUseCase.kt
@@ -1,13 +1,20 @@
 package com.gyleedev.githubsearch.domain.usecase
 
+import com.gyleedev.githubsearch.domain.model.RevokeResult
 import com.gyleedev.githubsearch.domain.repository.GitHubRepository
 import javax.inject.Inject
 
 class RevokeApplicationUseCase @Inject constructor(
     private val repository: GitHubRepository,
 ) {
-    suspend operator fun invoke() {
-        repository.revokeApplication()
-        repository.deleteAccessToken()
+    suspend operator fun invoke(): RevokeResult = try {
+        val result = repository.revokeApplication()
+        if (result == RevokeResult.SUCCESS) {
+            repository.deleteAccessToken()
+        }
+        result
+    } catch (e: Exception) {
+        // 어떤 실패인지 추가할 필요 있음
+        RevokeResult.FAIL
     }
 }

--- a/domain/src/test/java/com/gyleedev/domain/RevokeApplicationTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/RevokeApplicationTest.kt
@@ -1,0 +1,89 @@
+package com.gyleedev.domain
+
+import com.gyleedev.githubsearch.domain.model.RevokeResult
+import com.gyleedev.githubsearch.domain.repository.GitHubRepository
+import com.gyleedev.githubsearch.domain.usecase.RevokeApplicationUseCase
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class RevokeApplicationTest {
+    private val repository: GitHubRepository = mockk()
+    private lateinit var useCase: RevokeApplicationUseCase
+
+    @Before
+    fun setUp() {
+        useCase = RevokeApplicationUseCase(repository)
+    }
+
+    @Test
+    fun `Access Token이 존재하고 Revoke 에 성공했을 때`() = runTest {
+        // Given
+        val expected = RevokeResult.SUCCESS
+
+        // Repository 동작 정의
+        coEvery { repository.revokeApplication() } returns expected
+        coEvery { repository.deleteAccessToken() } just Runs
+
+        // When
+        val actual = useCase()
+
+        // Then
+        assertEquals(expected, actual)
+        coVerify(exactly = 1) { repository.deleteAccessToken() }
+    }
+
+    @Test
+    fun `Access Token이 존재하고 Revoke 에 실패했을 때`() = runTest {
+        // Given
+        val expected = RevokeResult.FAIL
+
+        // Repository 동작 정의
+        coEvery { repository.revokeApplication() } returns expected
+
+        // When
+        val actual = useCase()
+
+        // Then
+        assertEquals(expected, actual)
+        coVerify(exactly = 0) { repository.deleteAccessToken() }
+    }
+
+    @Test
+    fun `Access Token이 존재하지 않을 때`() = runTest {
+        // Given
+        val expected = RevokeResult.NO_KEY
+
+        // Repository 동작 정의
+        coEvery { repository.revokeApplication() } returns expected
+
+        // When
+        val actual = useCase()
+
+        // Then
+        assertEquals(expected, actual)
+        coVerify(exactly = 0) { repository.deleteAccessToken() }
+    }
+
+    @Test
+    fun `repository function 을 호출했을 때 Exception이 발생했을 때`() = runTest {
+        // Given
+        val expected = RevokeResult.FAIL
+
+        // Repository 동작 정의
+        coEvery { repository.revokeApplication() } throws Exception("Unknown Exception")
+
+        // When
+        val actual = useCase()
+
+        // Then
+        assertEquals(expected, actual)
+        coVerify(exactly = 0) { repository.deleteAccessToken() }
+    }
+}

--- a/feature/detail/build.gradle.kts
+++ b/feature/detail/build.gradle.kts
@@ -15,5 +15,8 @@ dependencies {
     implementation(libs.landscapist.glide)
     implementation(libs.landscapist.placeholder)
     implementation(libs.androidx.material.icons)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 composeCompiler { reportsDestination = layout.buildDirectory.dir("compose_reports") }

--- a/feature/favorite/build.gradle.kts
+++ b/feature/favorite/build.gradle.kts
@@ -16,5 +16,8 @@ dependencies {
     implementation(libs.landscapist.placeholder)
     implementation(libs.paging.compose)
     implementation(libs.androidx.material.icons)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 composeCompiler { reportsDestination = layout.buildDirectory.dir("compose_reports") }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -16,5 +16,8 @@ dependencies {
     implementation(libs.landscapist.placeholder)
     implementation(libs.paging.compose)
     implementation(libs.androidx.material.icons)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 composeCompiler { reportsDestination = layout.buildDirectory.dir("compose_reports") }

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -14,5 +14,8 @@ dependencies {
 
     implementation(libs.appcompat)
     implementation(libs.androidx.material.icons)
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 composeCompiler { reportsDestination = layout.buildDirectory.dir("compose_reports") }

--- a/feature/setting/src/main/java/com/gyleedev/githubsearch/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/gyleedev/githubsearch/feature/setting/SettingScreen.kt
@@ -13,16 +13,25 @@ import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.core.os.LocaleListCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
+import com.gyleedev.githubsearch.domain.model.RevokeResult
 import com.gyleedev.githubsearch.feature.setting.component.RadioButtonDialog
 import com.gyleedev.githubsearch.feature.setting.component.SettingMainBlock
 import com.gyleedev.githubsearch.feature.setting.component.TwoButtonDialog
@@ -32,6 +41,7 @@ import com.gyleedev.githubsearch.feature.setting.model.SettingEvent
 import com.gyleedev.githubsearch.feature.setting.model.SettingItem
 import com.gyleedev.githubsearch.feature.setting.model.SettingRowItem
 import com.gyleedev.githubsearch.feature.setting.model.ThemeItem
+import kotlinx.coroutines.flow.collectLatest
 import java.util.Locale
 import com.gyleedev.githubsearch.feature.setting.R as SettingR
 
@@ -46,6 +56,29 @@ fun SettingScreen(
     val themeData = remember { SettingDialogItem.Theme(themeList) }
     val languageData = remember { SettingDialogItem.Language(languageList) }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val snackBarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+    val revokeSuccessMessage = stringResource(id = SettingR.string.revoke_success_message)
+    val revokeFailMessage = stringResource(id = SettingR.string.revoke_fail_message)
+    val revokeNoKeyMessage = stringResource(id = SettingR.string.revoke_no_item_message)
+
+    LaunchedEffect(viewModel.showRevokeResult, lifecycleOwner, context) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.showRevokeResult.collectLatest { result ->
+                val message = when (result) {
+                    RevokeResult.SUCCESS -> revokeSuccessMessage
+                    RevokeResult.FAIL -> revokeFailMessage
+                    RevokeResult.NO_KEY -> revokeNoKeyMessage
+                }
+
+                snackBarHostState.showSnackbar(
+                    message = message,
+                    duration = SnackbarDuration.Short,
+                )
+            }
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -54,6 +87,7 @@ fun SettingScreen(
                 modifier = Modifier,
             )
         },
+        snackbarHost = { SnackbarHost(snackBarHostState) },
         modifier = modifier.fillMaxSize(),
     ) { paddingValues ->
 
@@ -120,7 +154,7 @@ fun SettingScreen(
                 TwoButtonDialog(
                     onDismissRequest = { viewModel.changDialogState(SettingEvent.LOGOUT) },
                     onEventRequest = {
-                        viewModel.deleteKey()
+                        viewModel.revokeApplication()
                         viewModel.changDialogState(SettingEvent.LOGOUT)
                     },
                     modifier = Modifier,

--- a/feature/setting/src/main/java/com/gyleedev/githubsearch/feature/setting/SettingViewModel.kt
+++ b/feature/setting/src/main/java/com/gyleedev/githubsearch/feature/setting/SettingViewModel.kt
@@ -1,13 +1,16 @@
 package com.gyleedev.githubsearch.feature.setting
 
 import androidx.lifecycle.viewModelScope
+import com.gyleedev.githubsearch.domain.model.RevokeResult
 import com.gyleedev.githubsearch.domain.usecase.CheckLoginStatusUseCase
 import com.gyleedev.githubsearch.domain.usecase.ResetDataUseCase
 import com.gyleedev.githubsearch.domain.usecase.RevokeApplicationUseCase
 import com.gyleedev.githubsearch.feature.setting.model.SettingEvent
 import com.gyleedev.ui.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -32,6 +35,8 @@ class SettingViewModel @Inject constructor(
     private val showResetDialog = MutableStateFlow(false)
     private val showLoginDialog = MutableStateFlow(false)
     private val showLogoutDialog = MutableStateFlow(false)
+    private val _showRevokeResult = MutableSharedFlow<RevokeResult>()
+    val showRevokeResult: SharedFlow<RevokeResult> = _showRevokeResult
 
     val uiState = combine(showThemeDialog, showLanguageDialog, showLoginDialog, showLogoutDialog, showResetDialog) { theme, lang, login, logout, reset ->
         SettingUiState.Success(
@@ -53,9 +58,9 @@ class SettingViewModel @Inject constructor(
         }
     }
 
-    fun deleteKey() {
+    fun revokeApplication() {
         viewModelScope.launch {
-            revokeApplicationUseCase()
+            _showRevokeResult.emit(revokeApplicationUseCase())
         }
     }
 

--- a/feature/setting/src/main/res/values/strings.xml
+++ b/feature/setting/src/main/res/values/strings.xml
@@ -21,4 +21,7 @@
     <string name="filter_default_theme">System Default</string>
     <string name="setting_korean">Korean</string>
     <string name="setting_english">English</string>
+    <string name="revoke_success_message">Successfully Revoke User Account</string>
+    <string name="revoke_fail_message">Revoke Request Failed</string>
+    <string name="revoke_no_item_message">Can\'t Make Request.No Access Key</string>
 </resources>


### PR DESCRIPTION
  개요 : 
  계정 권한 철회(Revoke Application) 처리 결과(RevokeResult)를 정의하고 이를 UI에서 사용자에게 피드백(SnackBar)으로  제공하도록 개선했습니다. 또한, 관련 비즈니스 로직에 대한 단위 테스트를 추가하여 안정성을 확보했습니다.

  주요 변경 사항

  1. Domain 계층
   * RevokeApplicationUseCase.kt 리팩터링:
       * 기존 Unit 반환에서 RevokeResult 타입을 반환하도록 수정했습니다.
       * 성공 시에만 로컬 액세스 토큰을 삭제하도록 로직을 변경했습니다.
       * try-catch 블록을 통해 예외 발생 시 RevokeResult.FAIL을 반환하도록 예외 처리를 추가했습니다.
   * RevokeApplicationTest.kt 추가:
       * MockK를 사용하여 RevokeApplicationUseCase의 4가지 시나리오(성공, 실패, 토큰 없음, 예외 발생)에 대한 단위 테스트를 작성했습니다.

  2. Feature 계층 (Setting)
   * SettingViewModel.kt 수정:
       * 권한 철회 결과를 UI로 전달하기 위한 showRevokeResult (SharedFlow)를 추가했습니다.
       * revokeApplication() 함수가 UseCase의 결과값을 받아 flow로 emit하도록 변경했습니다.
   * SettingScreen.kt UI 개선:
       * LaunchedEffect와 repeatOnLifecycle을 사용하여 권한 철회 결과를 구독하고, 결과에 따른 메시지를 Snackbar로 표시하도록 구현했습니다.
       * 계정 탈퇴 확인 다이얼로그의 이벤트 요청 함수를 revokeApplication()으로 연결했습니다.
   * 리소스 추가:
       * strings.xml에 권한 철회 결과(성공, 실패, 키 없음)를 알리는 다국어 문자열 리소스를 추가했습니다.

  3.  CI 스크립트
    * CI 스크립트에 test 관련 실행하도록 추가
    * 기존에는 테스트 코드가 없었기 때문에 스크립트를 넣어놓지 않았습니다.

  테스트 결과
   * 단위 테스트: RevokeApplicationTest 통과 확인.