### PR TITLE
 [Test & Refactor] Access Token 획득 로직 개선 및 단위 테스트 추가

### DIFF
--- a/app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt
@@ -45,6 +45,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.gyleedev.githubsearch.R
+import com.gyleedev.githubsearch.domain.model.GetAccessTokenUseCaseResult
 import com.gyleedev.githubsearch.feature.detail.DetailScreen
 import com.gyleedev.githubsearch.feature.favorite.FavoriteScreen
 import com.gyleedev.githubsearch.feature.home.HomeScreen
@@ -90,7 +91,10 @@ fun GithubSearchScreen(
     LaunchedEffect(viewModel.alertLoginSuccess, lifecycleOwner) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             viewModel.alertLoginSuccess.collectLatest { result ->
-                val message = if (result) loginSuccessMessage else loginFailMessage
+                val message = when (result) {
+                    GetAccessTokenUseCaseResult.Fail -> loginFailMessage
+                    GetAccessTokenUseCaseResult.Success -> loginSuccessMessage
+                }
                 snackBarHostState.showSnackbar(
                     message = message,
                     duration = SnackbarDuration.Short,

--- a/app/src/main/java/com/gyleedev/githubsearch/ui/MainViewModel.kt
+++ b/app/src/main/java/com/gyleedev/githubsearch/ui/MainViewModel.kt
@@ -3,6 +3,7 @@ package com.gyleedev.githubsearch.ui
 import android.net.Uri
 import androidx.lifecycle.viewModelScope
 import com.gyleedev.githubsearch.BuildConfig
+import com.gyleedev.githubsearch.domain.model.GetAccessTokenUseCaseResult
 import com.gyleedev.githubsearch.domain.usecase.GetAccessTokenUseCase
 import com.gyleedev.ui.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -19,8 +20,8 @@ getAccessTokenUseCase -> repositoryGetAccessToken 있으면 repositorySaveToken
 class MainViewModel @Inject constructor(
     private val getAccessTokenUseCase: GetAccessTokenUseCase,
 ) : BaseViewModel() {
-    private val _alertLoginSuccess = MutableSharedFlow<Boolean>()
-    val alertLoginSuccess: SharedFlow<Boolean> = _alertLoginSuccess
+    private val _alertLoginSuccess = MutableSharedFlow<GetAccessTokenUseCaseResult>()
+    val alertLoginSuccess: SharedFlow<GetAccessTokenUseCaseResult> = _alertLoginSuccess
 
     private val _launchOAuthEvent = MutableSharedFlow<String>()
     val launchOAuthEvent: SharedFlow<String> = _launchOAuthEvent

--- a/data/src/main/java/com/gyleedev/data/repository/GitHubRepositoryImpl.kt
+++ b/data/src/main/java/com/gyleedev/data/repository/GitHubRepositoryImpl.kt
@@ -21,7 +21,7 @@ import com.gyleedev.data.remote.TypeRevoke
 import com.gyleedev.data.remote.request.RevokeRequest
 import com.gyleedev.data.remote.response.toModel
 import com.gyleedev.githubsearch.domain.model.FilterStatus
-import com.gyleedev.githubsearch.domain.model.GithubAccessModel
+import com.gyleedev.githubsearch.domain.model.GetAccessTokenRepositoryResult
 import com.gyleedev.githubsearch.domain.model.RepositoryModel
 import com.gyleedev.githubsearch.domain.model.RevokeResult
 import com.gyleedev.githubsearch.domain.model.UserFetchResult
@@ -205,28 +205,23 @@ class GitHubRepositoryImpl @Inject constructor(
     }
 
     // Main
-    override suspend fun getAccessToken(code: String): GithubAccessModel? {
-        try {
-            val response =
-                accessService.getAccessToken(
-                    clientId = BuildConfig.CLIENT_ID,
-                    clientSecret = BuildConfig.CLIENT_SECRET,
-                    code = code,
-                )
-
-            if (response.isSuccessful && response.code() == 200) {
-                val body = response.body()
-
-                if (body != null) {
-                    val accessToken = body.accessToken
-
-                    return GithubAccessModel(accessToken = accessToken)
-                }
+    override suspend fun getAccessToken(code: String): GetAccessTokenRepositoryResult {
+        val response =
+            accessService.getAccessToken(
+                clientId = BuildConfig.CLIENT_ID,
+                clientSecret = BuildConfig.CLIENT_SECRET,
+                code = code,
+            )
+        return if (response.isSuccessful) {
+            val body = response.body()
+            if (body != null) {
+                val accessToken = body.accessToken
+                GetAccessTokenRepositoryResult.Success(token = accessToken)
+            } else {
+                GetAccessTokenRepositoryResult.Fail
             }
-
-            return null
-        } catch (e: Exception) {
-            return null
+        } else {
+            GetAccessTokenRepositoryResult.Fail
         }
     }
 

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/model/GetAccessTokenRepositoryResult.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/model/GetAccessTokenRepositoryResult.kt
@@ -1,0 +1,8 @@
+package com.gyleedev.githubsearch.domain.model
+
+sealed interface GetAccessTokenRepositoryResult {
+    data object Fail : GetAccessTokenRepositoryResult
+    data class Success(
+        val token: String,
+    ) : GetAccessTokenRepositoryResult
+}

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/model/GetAccessTokenUseCaseResult.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/model/GetAccessTokenUseCaseResult.kt
@@ -1,0 +1,6 @@
+package com.gyleedev.githubsearch.domain.model
+
+sealed interface GetAccessTokenUseCaseResult {
+    data object Fail : GetAccessTokenUseCaseResult
+    data object Success : GetAccessTokenUseCaseResult
+}

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/repository/GitHubRepository.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/repository/GitHubRepository.kt
@@ -3,7 +3,7 @@ package com.gyleedev.githubsearch.domain.repository
 import androidx.paging.PagingData
 import com.gyleedev.githubsearch.domain.model.AccessTime
 import com.gyleedev.githubsearch.domain.model.FilterStatus
-import com.gyleedev.githubsearch.domain.model.GithubAccessModel
+import com.gyleedev.githubsearch.domain.model.GetAccessTokenRepositoryResult
 import com.gyleedev.githubsearch.domain.model.RepositoryModel
 import com.gyleedev.githubsearch.domain.model.RevokeResult
 import com.gyleedev.githubsearch.domain.model.UserFetchResult
@@ -38,7 +38,7 @@ interface GitHubRepository {
 
     fun getFavorites(status: FilterStatus): Flow<PagingData<UserModel>>
 
-    suspend fun getAccessToken(code: String): GithubAccessModel?
+    suspend fun getAccessToken(code: String): GetAccessTokenRepositoryResult
 
     suspend fun resetData()
 

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/GetAccessTokenUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/GetAccessTokenUseCase.kt
@@ -1,19 +1,22 @@
 package com.gyleedev.githubsearch.domain.usecase
 
+import com.gyleedev.githubsearch.domain.model.GetAccessTokenRepositoryResult
+import com.gyleedev.githubsearch.domain.model.GetAccessTokenUseCaseResult
 import com.gyleedev.githubsearch.domain.repository.GitHubRepository
 import javax.inject.Inject
 
 class GetAccessTokenUseCase @Inject constructor(
     private val repository: GitHubRepository,
 ) {
-    suspend operator fun invoke(code: String): Boolean {
-        val response = repository.getAccessToken(code = code)
-
-        return if (response != null) {
-            repository.saveAccessToken(token = response.accessToken)
-            true
+    suspend operator fun invoke(code: String): GetAccessTokenUseCaseResult = try {
+        val result = repository.getAccessToken(code = code)
+        if (result is GetAccessTokenRepositoryResult.Success) {
+            repository.saveAccessToken(token = result.token)
+            GetAccessTokenUseCaseResult.Success
         } else {
-            false
+            GetAccessTokenUseCaseResult.Fail
         }
+    } catch (e: Exception) {
+        GetAccessTokenUseCaseResult.Fail
     }
 }

--- a/domain/src/test/java/com/gyleedev/domain/GetAccessTokenTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/GetAccessTokenTest.kt
@@ -88,4 +88,3 @@ class GetAccessTokenTest {
         coVerify(exactly = 0) { repository.saveAccessToken(any()) }
     }
 }
-

--- a/domain/src/test/java/com/gyleedev/domain/GetAccessTokenTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/GetAccessTokenTest.kt
@@ -1,0 +1,91 @@
+package com.gyleedev.domain
+
+import com.gyleedev.githubsearch.domain.model.GetAccessTokenRepositoryResult
+import com.gyleedev.githubsearch.domain.model.GetAccessTokenUseCaseResult
+import com.gyleedev.githubsearch.domain.repository.GitHubRepository
+import com.gyleedev.githubsearch.domain.usecase.GetAccessTokenUseCase
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifySequence
+import io.mockk.just
+import io.mockk.mockk
+import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class GetAccessTokenTest {
+    private val repository: GitHubRepository = mockk()
+    private lateinit var useCase: GetAccessTokenUseCase
+
+    @Before
+    fun setUp() {
+        useCase = GetAccessTokenUseCase(repository)
+    }
+
+    @Test
+    fun `AccessToken 가져오기 성공`() = runTest {
+        // Given
+        val token = "token"
+        val code = "code"
+        val expectedValue = GetAccessTokenRepositoryResult.Success(token = token)
+        val expectedResult = GetAccessTokenUseCaseResult.Success
+
+        // Repository 동작 정의
+        coEvery { repository.getAccessToken(code) } returns expectedValue
+        coEvery { repository.saveAccessToken(token) } just Runs
+
+        // When
+        val actualResult = useCase(code)
+
+        // Then
+
+        assertEquals(expectedResult, actualResult)
+        coVerifySequence {
+            repository.getAccessToken(code)
+            repository.saveAccessToken(token)
+        }
+    }
+
+    @Test
+    fun `AccessToken 가져오기 실패`() = runTest {
+        // Given
+        val code = "code"
+        val expectedValue = GetAccessTokenRepositoryResult.Fail
+        val expectedResult = GetAccessTokenUseCaseResult.Fail
+
+        // Repository 동작 정의
+        coEvery { repository.getAccessToken(code) } returns expectedValue
+        coEvery { repository.saveAccessToken(any()) } just Runs
+
+        // When
+        val actualResult = useCase(code)
+
+        // Then
+        assertEquals(expectedResult, actualResult)
+        coVerify(exactly = 1) { repository.getAccessToken(code) }
+        coVerify(exactly = 0) { repository.saveAccessToken(any()) }
+    }
+
+    @Test
+    fun `Exception 나왔을때`() = runTest {
+        // Given
+        val exception = Exception("Unknown Exception")
+        val code = "code"
+        val expectedResult = GetAccessTokenUseCaseResult.Fail
+
+        // Repository 동작 정의
+        coEvery { repository.getAccessToken(code) } throws exception
+        coEvery { repository.saveAccessToken(any()) } just Runs
+
+        // When
+        val actualResult = useCase(code)
+
+        // Then
+        assertEquals(expectedResult, actualResult)
+        coVerify(exactly = 1) { repository.getAccessToken(code) }
+        coVerify(exactly = 0) { repository.saveAccessToken(any()) }
+    }
+}
+


### PR DESCRIPTION
  개요
  Github Access Token을 가져오는 과정에서 발생할 수 있는 다양한 결과 상태를 정의하고, 로직의 안정성을 높이기 위해 리팩터링을 진행했습니다. 또한, 해당 UseCase에 대한 단위 테스트를 추가하여 동작을 검증했습니다.

  주요 변경 사항

  1. Domain 계층
   * 결과 모델 추가: GetAccessTokenRepositoryResult 및 GetAccessTokenUseCaseResult를 도입하여 성공, 실패(에러), 빈 값 등 다양한 시나리오를 명확하게
     표현하도록 수정했습니다.
   * UseCase 개선: GetAccessTokenUseCase에서 try-catch 문을 사용하여 예외 상황에 대비하고, 결과에 따른 명확한 상태를 반환하도록 변경했습니다.
   * Repository 인터페이스 수정: 구현체의 변경된 반환 타입을 인터페이스에 반영했습니다.

  2. Data 계층
   * GitHubRepositoryImpl 리팩터링: API 응답 결과에 따라 GetAccessTokenRepositoryResult의 각 상태(Success, Error 등)를 반환하도록 로직을 정교화했습니다.

  3. Presentation (App) 계층
   * MainViewModel: UseCase의 반환 타입 변경에 맞춰 로그인 결과 처리 로직을 수정했습니다.
   * GithubSearchScreen: 로그인 성공/실패 알림 로직을 when 문으로 개선하여 향후 다양한 결과 패턴에 유연하게 대응할 수 있도록 구조를 변경했습니다.

  4. Test
   * GetAccessTokenTest 추가: 다양한 네트워크 상황 및 응답 결과(정상 토큰, 에러, 빈 값 등)에 대해 GetAccessTokenUseCase가 올바른 결과를 반환하는지 검증하는 단위 테스트를 작성했습니다.

  TODO
   * 현재 에러 발생 시 공통된 에러 상태를 반환하고 있는데, 향후 에러 타입별(네트워크 오류, 인증 오류 등)로 더 세분화된 처리가 필요합니다