### PR TITLE
Feat(Build) : JaCoCo 도입 및 실시간 테스트 커버리지 대시보드 자동화 구축

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
       - '**.md'
       - 'docs/**'
       - '.github/workflows/**'
+  push:
+    branches: [ main ]
 
 concurrency:
   group: build-${{ github.ref }}
@@ -13,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    name: "Build"
+    name: "Build & Coverage"
     runs-on: ubuntu-latest
 
     permissions:
@@ -40,8 +42,33 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
-      - name: Check and Build and Test
+      - name: Check and Build and Test with Coverage
         env:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-        run: ./gradlew spotlessCheck assembleDebug testDebugUnitTest --parallel --build-cache --configure-on-demand
+        run: ./gradlew spotlessCheck assembleDebug testDebugUnitTest jacocoFullReport --parallel --build-cache --configure-on-demand
+
+      - name: Post JaCoCo Report Comment
+        if: github.event_name == 'pull_request'
+        uses: Madrapps/jacoco-report@v1.7.1
+        with:
+          paths: |
+            ${{ github.workspace }}/build/reports/jacoco/jacocoFullReport/jacocoFullReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 0
+          min-coverage-changed-files: 0
+          title: "📈 테스트 커버리지 리포트"
+          update-comment: true
+
+      - name: Upload Report Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/jacocoFullReport/html
+
+      - name: Deploy Coverage to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/reports/jacoco/jacocoFullReport/html

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,70 +60,58 @@ jobs:
           title: "📈 테스트 커버리지 리포트"
           update-comment: true
 
-      - name: Upload Report Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: jacoco-report
-          path: build/reports/jacoco/jacocoFullReport/html
-
-      - name: Deploy Coverage to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build/reports/jacoco/jacocoFullReport/html
-
-      - name: Update README Coverage
+      - name: Generate Coverage Badges Data
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           REPORT_PATH="build/reports/jacoco/jacocoFullReport/jacocoFullReport.xml"
+          mkdir -p build/badges
           
-          # XML에서 지표 추출 (Instruction 기준)
           extract_coverage() {
             local package=$1
             if [ -z "$package" ]; then
-              # Total Coverage
               missed=$(grep -oPm1 '(?<=</package><counter type="INSTRUCTION" missed=")[0-9]+' "$REPORT_PATH" || echo 0)
               covered=$(grep -oPm1 '(?<=</package><counter type="INSTRUCTION" missed="'$missed'" covered=")[0-9]+' "$REPORT_PATH" || echo 0)
             else
-              # Package Specific Coverage
               line=$(grep "package name=\"$package\"" "$REPORT_PATH" -A 10 | grep "counter type=\"INSTRUCTION\"" | head -n 1)
               missed=$(echo "$line" | grep -oP '(?<=missed=")[0-9]+' || echo 0)
               covered=$(echo "$line" | grep -oP '(?<=covered=")[0-9]+' || echo 0)
             fi
-            
             total=$((missed + covered))
-            if [ "$total" -eq 0 ]; then
-              echo 0
-            else
-              echo $((covered * 100 / total))
-            fi
+            if [ "$total" -eq 0 ]; then echo 0; else echo $((covered * 100 / total)); fi
+          }
+
+          get_color() {
+            if [ "$1" -ge 80 ]; then echo "brightgreen"; elif [ "$1" -ge 60 ]; then echo "green"; elif [ "$1" -ge 40 ]; then echo "orange"; else echo "red"; fi
+          }
+
+          create_badge_json() {
+            local label=$1
+            local value=$2
+            local color=$(get_color $value)
+            echo "{\"schemaVersion\": 1, \"label\": \"$label\", \"message\": \"$value%\", \"color\": \"$color\"}" > "build/badges/$3-coverage.json"
           }
 
           DOMAIN_COV=$(extract_coverage "com/gyleedev/domain")
           DATA_COV=$(extract_coverage "com/gyleedev/data")
           TOTAL_COV=$(extract_coverage "")
 
-          # 배지 색상 결정 함수
-          get_color() {
-            if [ "$1" -ge 80 ]; then echo "brightgreen"; elif [ "$1" -ge 60 ]; then echo "green"; elif [ "$1" -ge 40 ]; then echo "orange"; else echo "red"; fi
-          }
+          create_badge_json "Domain" $DOMAIN_COV "domain"
+          create_badge_json "Data" $DATA_COV "data"
+          create_badge_json "Total" $TOTAL_COV "total"
 
-          DOMAIN_COLOR=$(get_color $DOMAIN_COV)
-          DATA_COLOR=$(get_color $DATA_COV)
-          TOTAL_COLOR=$(get_color $TOTAL_COV)
-          UPDATE_DATE=$(date +'%Y-%m-%d')
-
-          # README.md 내용 업데이트
-          NEW_REPORT="| Layer | Instruction Coverage | Details |\n| :--- | :---: | :---: |\n| **Domain** | ![Domain Coverage](https://img.shields.io/badge/Coverage-$DOMAIN_COV%25-$DOMAIN_COLOR) | [상세보기 🔍](https://ThinkGYLee.github.io/GithubSearch/) |\n| **Data** | ![Data Coverage](https://img.shields.io/badge/Coverage-$DATA_COV%25-$DATA_COLOR) | [상세보기 🔍](https://ThinkGYLee.github.io/GithubSearch/) |\n| **Total** | ![Total Coverage](https://img.shields.io/badge/Coverage-$TOTAL_COV%25-$TOTAL_COLOR) | [전체 리포트 📄](https://ThinkGYLee.github.io/GithubSearch/) |\n\n최근 업데이트: $UPDATE_DATE"
-          
-          sed -i "/<!-- START_COVERAGE_REPORT -->/,/<!-- END_COVERAGE_REPORT -->/c\<!-- START_COVERAGE_REPORT -->\n$NEW_REPORT\n<!-- END_COVERAGE_REPORT -->" README.md
-
-      - name: Commit and Push README changes
+      - name: Deploy Coverage and Badges to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add README.md
-          git diff --quiet && git diff --staged --quiet || git commit -m "docs: README 테스트 커버리지 대시보드 업데이트"
-          git push
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/reports/jacoco/jacocoFullReport/html
+          destination_dir: .
+          
+      - name: Deploy Badges Data to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/badges
+          destination_dir: badges
+          keep_files: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,3 +72,58 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/reports/jacoco/jacocoFullReport/html
+
+      - name: Update README Coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          REPORT_PATH="build/reports/jacoco/jacocoFullReport/jacocoFullReport.xml"
+          
+          # XML에서 지표 추출 (Instruction 기준)
+          extract_coverage() {
+            local package=$1
+            if [ -z "$package" ]; then
+              # Total Coverage
+              missed=$(grep -oPm1 '(?<=</package><counter type="INSTRUCTION" missed=")[0-9]+' "$REPORT_PATH" || echo 0)
+              covered=$(grep -oPm1 '(?<=</package><counter type="INSTRUCTION" missed="'$missed'" covered=")[0-9]+' "$REPORT_PATH" || echo 0)
+            else
+              # Package Specific Coverage
+              line=$(grep "package name=\"$package\"" "$REPORT_PATH" -A 10 | grep "counter type=\"INSTRUCTION\"" | head -n 1)
+              missed=$(echo "$line" | grep -oP '(?<=missed=")[0-9]+' || echo 0)
+              covered=$(echo "$line" | grep -oP '(?<=covered=")[0-9]+' || echo 0)
+            fi
+            
+            total=$((missed + covered))
+            if [ "$total" -eq 0 ]; then
+              echo 0
+            else
+              echo $((covered * 100 / total))
+            fi
+          }
+
+          DOMAIN_COV=$(extract_coverage "com/gyleedev/domain")
+          DATA_COV=$(extract_coverage "com/gyleedev/data")
+          TOTAL_COV=$(extract_coverage "")
+
+          # 배지 색상 결정 함수
+          get_color() {
+            if [ "$1" -ge 80 ]; then echo "brightgreen"; elif [ "$1" -ge 60 ]; then echo "green"; elif [ "$1" -ge 40 ]; then echo "orange"; else echo "red"; fi
+          }
+
+          DOMAIN_COLOR=$(get_color $DOMAIN_COV)
+          DATA_COLOR=$(get_color $DATA_COV)
+          TOTAL_COLOR=$(get_color $TOTAL_COV)
+          UPDATE_DATE=$(date +'%Y-%m-%d')
+
+          # README.md 내용 업데이트
+          NEW_REPORT="| Layer | Instruction Coverage | Details |\n| :--- | :---: | :---: |\n| **Domain** | ![Domain Coverage](https://img.shields.io/badge/Coverage-$DOMAIN_COV%25-$DOMAIN_COLOR) | [상세보기 🔍](https://ThinkGYLee.github.io/GithubSearch/) |\n| **Data** | ![Data Coverage](https://img.shields.io/badge/Coverage-$DATA_COV%25-$DATA_COLOR) | [상세보기 🔍](https://ThinkGYLee.github.io/GithubSearch/) |\n| **Total** | ![Total Coverage](https://img.shields.io/badge/Coverage-$TOTAL_COV%25-$TOTAL_COLOR) | [전체 리포트 📄](https://ThinkGYLee.github.io/GithubSearch/) |\n\n최근 업데이트: $UPDATE_DATE"
+          
+          sed -i "/<!-- START_COVERAGE_REPORT -->/,/<!-- END_COVERAGE_REPORT -->/c\<!-- START_COVERAGE_REPORT -->\n$NEW_REPORT\n<!-- END_COVERAGE_REPORT -->" README.md
+
+      - name: Commit and Push README changes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add README.md
+          git diff --quiet && git diff --staged --quiet || git commit -m "docs: README 테스트 커버리지 대시보드 업데이트"
+          git push

--- a/README.md
+++ b/README.md
@@ -9,15 +9,11 @@
 - 페이징
 
 ## 📈 테스트 커버리지 리포트
-<!-- START_COVERAGE_REPORT -->
 | Layer | Instruction Coverage | Details |
 | :--- | :---: | :---: |
-| **Domain** | ![Domain Coverage](https://img.shields.io/badge/Coverage-0%25-red) | [상세보기 🔍](https://ThinkGYLee.github.io/GithubSearch/) |
-| **Data** | ![Data Coverage](https://img.shields.io/badge/Coverage-0%25-red) | [상세보기 🔍](https://ThinkGYLee.github.io/GithubSearch/) |
-| **Total** | ![Total Coverage](https://img.shields.io/badge/Coverage-0%25-red) | [전체 리포트 📄](https://ThinkGYLee.github.io/GithubSearch/) |
-
-최근 업데이트: 2026-05-17
-<!-- END_COVERAGE_REPORT -->
+| **Domain** | ![Domain](https://img.shields.io/endpoint?url=https://ThinkGYLee.github.io/GithubSearch/badges/domain-coverage.json) | [상세보기 🔍](https://ThinkGYLee.github.io/GithubSearch/) |
+| **Data** | ![Data](https://img.shields.io/endpoint?url=https://ThinkGYLee.github.io/GithubSearch/badges/data-coverage.json) | [상세보기 🔍](https://ThinkGYLee.github.io/GithubSearch/) |
+| **Total** | ![Total](https://img.shields.io/endpoint?url=https://ThinkGYLee.github.io/GithubSearch/badges/total-coverage.json) | [전체 리포트 📄](https://ThinkGYLee.github.io/GithubSearch/) |
 
 ## 기술 스택
  구분 | 내용
@@ -259,4 +255,3 @@ fun getAccessToken(code: String) {
         }
     }
 ```
-

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@
 - 네트워크 콜 최적화
 - 페이징
 
+## 📈 테스트 커버리지 리포트
+<!-- START_COVERAGE_REPORT -->
+| Layer | Instruction Coverage | Details |
+| :--- | :---: | :---: |
+| **Domain** | ![Domain Coverage](https://img.shields.io/badge/Coverage-0%25-red) | [상세보기 🔍](https://ThinkGYLee.github.io/GithubSearch/) |
+| **Data** | ![Data Coverage](https://img.shields.io/badge/Coverage-0%25-red) | [상세보기 🔍](https://ThinkGYLee.github.io/GithubSearch/) |
+| **Total** | ![Total Coverage](https://img.shields.io/badge/Coverage-0%25-red) | [전체 리포트 📄](https://ThinkGYLee.github.io/GithubSearch/) |
+
+최근 업데이트: 2026-05-17
+<!-- END_COVERAGE_REPORT -->
+
 ## 기술 스택
  구분 | 내용
 -- | --

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -46,5 +46,9 @@ gradlePlugin {
             id = "gyleedev.android.library.compose"
             implementationClass = "AndroidLibraryComposeConventionPlugin"
         }
+        register("androidJacoco") {
+            id = "gyleedev.android.jacoco"
+            implementationClass = "AndroidJacocoConventionPlugin"
+        }
     }
 }

--- a/build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -13,6 +13,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("com.android.application")
+                apply("gyleedev.android.jacoco")
             }
 
             configure<ApplicationExtension> {
@@ -22,6 +23,9 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 defaultConfig.versionName = libs.findVersion("app-versionName").get().requiredVersion
 
                 buildTypes {
+                    getByName("debug") {
+                        enableUnitTestCoverage = true
+                    }
                     getByName("release") {
                         isMinifyEnabled = true
                         isShrinkResources = true

--- a/build-logic/src/main/kotlin/AndroidJacocoConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidJacocoConventionPlugin.kt
@@ -1,0 +1,27 @@
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import com.gyleedev.build_logic.configureJacoco
+import com.gyleedev.build_logic.configureJacocoJvm
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.findByType
+
+class AndroidJacocoConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            with(pluginManager) {
+                apply("org.gradle.jacoco")
+            }
+
+            val androidExtension = extensions.findByType<ApplicationAndroidComponentsExtension>()
+                ?: extensions.findByType<LibraryAndroidComponentsExtension>()
+
+            if (androidExtension != null) {
+                configureJacoco(androidExtension)
+            } else {
+                // Android 플러그인이 없는 경우에만 JVM용 Jacoco 설정 적용
+                configureJacocoJvm()
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -13,6 +13,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("com.android.library")
+                apply("gyleedev.android.jacoco")
             }
 
             configure<LibraryExtension> {
@@ -24,6 +25,9 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
                     defaultConfig.buildConfigField("String", "VERSION_NAME", "\"$versionName\"")
                 }
                 buildTypes {
+                    getByName("debug") {
+                        enableUnitTestCoverage = true
+                    }
                     getByName("release") {
                         isMinifyEnabled = false
                     }

--- a/build-logic/src/main/kotlin/JvmLibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/JvmLibraryConventionPlugin.kt
@@ -15,6 +15,7 @@ class JvmLibraryConventionPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("org.jetbrains.kotlin.jvm")
+                apply("gyleedev.android.jacoco")
             }
 
             configure<JavaPluginExtension> {

--- a/build-logic/src/main/kotlin/com/gyleedev/build_logic/Jacoco.kt
+++ b/build-logic/src/main/kotlin/com/gyleedev/build_logic/Jacoco.kt
@@ -1,0 +1,117 @@
+package com.gyleedev.build_logic
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.gradle.testing.jacoco.tasks.JacocoReport
+
+private val fileFilter = listOf(
+    "**/R.class",
+    "**/R$*.class",
+    "**/BuildConfig.*",
+    "**/Manifest*.*",
+    "**/*Test*.*",
+    "android/**/*.*",
+    "**/*\$Lambda$*.*",
+    "**/*\$ExternalSynthetic$*.*",
+    "**/*\$TypeAdapter$*.*",
+    "**/*Hilt*.*",
+    "**/Dagger*.*",
+    "**/*_Factory.*",
+    "**/*_MembersInjector.*",
+    "**/*_Impl*.*",
+    "**/*Binding.*"
+)
+
+internal fun Project.configureJacoco(
+    androidComponentsExtension: AndroidComponentsExtension<*, *, *>,
+) {
+    configureJacocoCommon()
+
+    if (tasks.findByName("jacocoTestReport") == null) {
+        tasks.register<JacocoReport>("jacocoTestReport") {
+            group = "Reporting"
+            description = "Generate Jacoco coverage reports for the debug build."
+
+            reports {
+                xml.required.set(true)
+                html.required.set(true)
+            }
+
+            val javaClasses = fileTree(layout.buildDirectory.dir("intermediates/javac/debug/compileDebugJavaWithJavac/classes")) {
+                exclude(fileFilter)
+            }
+            val kotlinClasses = fileTree(layout.buildDirectory.dir("intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes")) {
+                exclude(fileFilter)
+            }
+
+            classDirectories.setFrom(files(javaClasses, kotlinClasses))
+
+            sourceDirectories.setFrom(
+                files(
+                    "$projectDir/src/main/java",
+                    "$projectDir/src/main/kotlin"
+                )
+            )
+
+            executionData.setFrom(
+                fileTree(layout.buildDirectory) {
+                    include("jacoco/testDebugUnitTest.exec")
+                    include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
+                }
+            )
+        }
+    }
+}
+
+internal fun Project.configureJacocoJvm() {
+    configureJacocoCommon()
+
+    if (tasks.findByName("jacocoTestReport") == null) {
+        tasks.register<JacocoReport>("jacocoTestReport") {
+            group = "Reporting"
+            description = "Generate Jacoco coverage reports for the JVM build."
+
+            reports {
+                xml.required.set(true)
+                html.required.set(true)
+            }
+
+            val jvmClasses = fileTree(layout.buildDirectory.dir("classes/kotlin/main")) {
+                exclude(fileFilter)
+            }
+
+            classDirectories.setFrom(files(jvmClasses))
+
+            sourceDirectories.setFrom(
+                files(
+                    "$projectDir/src/main/java",
+                    "$projectDir/src/main/kotlin"
+                )
+            )
+
+            executionData.setFrom(
+                fileTree(layout.buildDirectory) {
+                    include("jacoco/test.exec")
+                }
+            )
+        }
+    }
+}
+
+private fun Project.configureJacocoCommon() {
+    configure<JacocoPluginExtension> {
+        toolVersion = libs.findVersion("jacoco").get().toString()
+    }
+
+    tasks.withType<Test>().configureEach {
+        configure<org.gradle.testing.jacoco.plugins.JacocoTaskExtension> {
+            isIncludeNoLocationClasses = true
+            excludes = listOf("jdk.internal.*")
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,79 @@ plugins {
     alias(libs.plugins.library) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
+    jacoco
 }
 
+val fileFilter = listOf(
+    "**/R.class",
+    "**/R$*.class",
+    "**/BuildConfig.*",
+    "**/Manifest*.*",
+    "**/*Test*.*",
+    "android/**/*.*",
+    "**/*\$Lambda$*.*",
+    "**/*\$ExternalSynthetic$*.*",
+    "**/*\$TypeAdapter$*.*",
+    "**/*Hilt*.*",
+    "**/Dagger*.*",
+    "**/*_Factory.*",
+    "**/*_MembersInjector.*",
+    "**/*_Impl*.*",
+    "**/*Binding.*"
+)
 
+tasks.register<JacocoReport>("jacocoFullReport") {
+    group = "Reporting"
+    description = "전체 모듈의 테스트 커버리지 리포트를 통합하여 생성합니다."
+
+    dependsOn(subprojects.mapNotNull { it.tasks.findByName("testDebugUnitTest") })
+    dependsOn(subprojects.mapNotNull { it.tasks.findByName("test") })
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+
+    val classDirectoriesList = mutableListOf<FileTree>()
+    val sourceDirectoriesList = mutableListOf<FileCollection>()
+    val executionDataList = mutableListOf<FileCollection>()
+
+    subprojects {
+        val project = this
+        val buildDir = project.layout.buildDirectory
+
+        classDirectoriesList.add(
+            project.fileTree(buildDir.dir("intermediates/javac/debug/compileDebugJavaWithJavac/classes")) {
+                exclude(fileFilter)
+            }
+        )
+        classDirectoriesList.add(
+            project.fileTree(buildDir.dir("intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes")) {
+                exclude(fileFilter)
+            }
+        )
+        classDirectoriesList.add(
+            project.fileTree(buildDir.dir("classes/kotlin/main")) {
+                exclude(fileFilter)
+            }
+        )
+
+        sourceDirectoriesList.add(project.files("${project.projectDir}/src/main/java"))
+        sourceDirectoriesList.add(project.files("${project.projectDir}/src/main/kotlin"))
+
+        executionDataList.add(
+            project.fileTree(buildDir) {
+                include("jacoco/testDebugUnitTest.exec")
+                include("jacoco/test.exec")
+                include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
+            }
+        )
+    }
+
+    classDirectories.setFrom(files(classDirectoriesList))
+    sourceDirectories.setFrom(files(sourceDirectoriesList))
+    executionData.setFrom(files(executionDataList))
+}
 
 subprojects {
     plugins.apply("com.diffplug.spotless")

--- a/docs/plan/JACOCO_SETUP_PLAN.md
+++ b/docs/plan/JACOCO_SETUP_PLAN.md
@@ -1,0 +1,70 @@
+# [고도화] JaCoCo 도입 및 테스트 자동화 파이프라인 수립 플랜
+
+이 플랜은 `GithubSearch` 프로젝트의 테스트 신뢰성을 지표로 시각화하고, 고품질의 테스트 코드를 유지하기 위한 엄격한 기준과 자동화 환경을 구축하는 것을 목표로 합니다.
+
+## 1. 목적
+- **객관적 지표 확보**: JaCoCo를 통해 테스트 커버리지를 측정하고 시각화합니다.
+- **테스트 품질 강화**: 한글 메서드 네이밍 및 Given-When-Then 구조를 통한 직관적인 테스트 코드를 작성합니다.
+- **피드백 루프 자동화**: GitHub Actions를 통해 PR 단계에서 커버리지 리포트를 자동으로 제공합니다.
+
+## 2. 주요 구성 요소
+- **JaCoCo**: 코드 커버리지 측정 엔진.
+- **GitHub Actions**: CI 파이프라인 (테스트 및 리포트 생성).
+- **Madrapps/jacoco-report**: PR 코멘트 자동화 도구.
+- **Testing Convention**: 한글 네이밍 및 G-W-T 구조.
+
+## 3. 상세 구현 단계
+
+### 1단계: 인프라 구축 (JaCoCo 플러그인 및 설정)
+- **버전 관리**: `libs.versions.toml`에 JaCoCo 버전을 추가합니다.
+- **Convention Plugin (`build-logic`)**:
+    - `AndroidJacocoConventionPlugin.kt`: 모든 안드로이드 모듈에 적용할 공통 JaCoCo 설정을 정의합니다.
+    - `jacocoTestReport` 태스크 정의: XML 및 HTML 리포트 생성을 설정합니다.
+- **Exclusion 리스트 등록**: 
+    - UI 관련: `**/*Activity*.*`, `**/*Fragment*.*`, `**/*Screen*.*` (Compose)
+    - DI/Generated: `**/*Hilt*.*`, `**/Dagger*.*`, `**/*_Factory.*`, `**/*_MembersInjector.*`
+    - 기타: `**/BuildConfig.*`, `**/Manifest*.*`, `**/*_Impl*.*` (Room)
+
+### 2단계: 테스트 코드 표준화 (Given-When-Then & 한글 네이밍)
+- **네이밍 규칙**: 테스트 의도를 직관적으로 파악할 수 있도록 **한글 공백 네이밍**을 사용합니다.
+    - 예: `` fun `사용자가 검색어를 입력하면 올바른 결과를 반환한다`() ``
+- **구조화**: 모든 테스트 메서드 내에 `// Given`, `// When`, `// Then` 주석을 명시하여 논리적 단계를 구분합니다.
+- **대상**: ViewModel, Repository, UseCase 등 비즈니스 로직이 포함된 모든 클래스.
+
+### 3단계: CI 파이프라인 자동화 (GitHub Actions)
+- **Workflow 작성**: `.github/workflows/jacoco-report.yml`
+    - 트리거: `pull_request` (target: main, develop)
+    - 명령어: `./gradlew testDebugUnitTest jacocoFullReport` (통합 리포트 생성)
+- **GitHub Pages 배포**: `main` 브랜치 머지 시 전체 커버리지 HTML 리포트를 배포하여 히스토리를 관리합니다.
+
+### 4단계: PR Comment 피드백 자동화
+- **Madrapps/jacoco-report 액션 연동**:
+    - JaCoCo가 생성한 XML 리포트를 분석합니다.
+    - PR 댓글로 전체 커버리지 요약(%)과 파일별 커버리지 변화를 리포팅합니다.
+    - 설정된 기준(초기 0%로 설정하여 도입 후 점진적으로 상향) 미달 시 빌드 실패 처리를 검토합니다.
+
+## 4. 기대 효과 및 향후 관리
+- **가시성**: 코드 변경이 테스트 커버리지에 미치는 영향을 즉각적으로 확인.
+- **유지보수성**: 한글 네이밍과 구조화된 테스트를 통해 누구나 쉽게 테스트 코드를 읽고 수정 가능.
+- **품질 유지**: 자동화된 검증 단계를 통해 테스트 없는 코드의 머지를 방지.
+
+## 5. 제외 패턴 (Exclusions) 상세 목록
+```kotlin
+val fileFilter = mutableListOf(
+    "**/R.class",
+    "**/R$*.class",
+    "**/BuildConfig.*",
+    "**/Manifest*.*",
+    "**/*Test*.*",
+    "android/**/*.*",
+    "**/*$Lambda$*.*",
+    "**/*$ExternalSynthetic$*.*",
+    "**/*$TypeAdapter$*.*",
+    "**/*Hilt*.*",
+    "**/Dagger*.*",
+    "**/*_Factory.*",
+    "**/*_MembersInjector.*",
+    "**/*_Impl*.*",
+    "**/*Binding.*"
+)
+```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ jetbrainsKotlinJvm = "2.3.21"
 app-versionCode = "1"
 app-versionName = "1.0.0"
 project-targetSdk = "36"
-
+jacoco = "0.8.12"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
 1. 개요 (Overview)
  - 프로젝트의 테스트 신뢰성을 시각화하고 코드 품질을 체계적으로 관리하기 위해 JaCoCo(Java Code Coverage)를 도입
  - CI가 메인 브랜치에 직접 커밋을 남기는 기존의 불편한 방식을 개선하여, 실시간 JSON 엔드포인트 배지 시스템을 통해 README.md를 최신화하는 최적화된 구조를 구현

  ---

  2. 주요 변경 사항 (Key Changes)

  JaCoCo 인프라 및 멀티 모듈 통합
   * 전용 컨벤션 플러그인 구현: AndroidJacocoConventionPlugin을 통해 Android(App/Library) 및 JVM 모듈에 JaCoCo 설정을 자동
   * AGP 9.x 호환성 최적화: enableUnitTestCoverage 활성화 및 최신 컴파일 경로 반영을 통해 정확한 수치를 집계
   * 통합 리포트(jacocoFullReport): 모든 모듈의 커버리지를 하나로 합친 통합 HTML/XML 리포트를 생성

  실시간 README 대시보드 자동화 (The Clean Way)
   * JSON 엔드포인트 배지 도입: CI가 README.md를 직접 수정하는 대신, 수치 정보를 담은 JSON 파일을 gh-pages 브랜치에 배포
   * No Auto-Commit & No Pull: README.md는 배포된 JSON을 실시간 참조하므로, 메인 브랜치에 CI 커밋이 남지 않아 히스토리가 깔끔하며 로컬에서 수동으로 pull을 받지 않음
   * 레이어별 지표 제공: Domain, Data 레이어의 개별 수치와 프로젝트 전체 수치를 README.md 상단에서 배지 형태로 즉시 확인할 수 있음

  CI/CD 파이프라인 통합
   * PR 자동 피드백: PR 생성 시 커버리지 요약 리포트를 댓글로 자동 게시
   * GitHub Pages 배포: 최신 통합 리포트와 배지 데이터를 웹으로 상시 공유

  ---

  3. 기술적 결정 및 이유 (Technical Decisions & Rationale)

   * 왜 JSON 배지 방식인가?: CI가 메인 브랜치에 직접 커밋을 남기는 방식은 로컬과 원격의 상태 불일치를 유발하여 git pull을 강제하게 됩니다. JSON 엔드포인트 방식은 문서 자체를 수정하지 않고 데이터만 교체하므로 Git 워크플로우를 방해하지 않는 가장 현대적이고 깔끔한 방식이라고 판단함
   * 정밀한 필터링(Exclusion): UI 클래스, DI 생성 코드, DB 구현체 등 비즈니스 로직과 무관한 코드를 측정 대상에서 제외하여 리포트의 신뢰도를 높임
   * 유연한 기준치: 초기 실패 기준치를 0%로 설정하여, 구축 단계에서 개발 흐름을 저해하지 않으면서 점진적으로 품질을 높일 수 있도록 설계함

  ---

  4. 사용 및 확인 방법 (How to use)

  로컬에서 확인

   1 ./gradlew jacocoFullReport
   2 # 리포트 경로: build/reports/jacoco/jacocoFullReport/html/index.html

  웹에서 확인 (Main 머지 후)
   * 상세 리포트: https://ThinkGYLee.github.io/GithubSearch/
   * README 대시보드: 저장소 메인 페이지 상단에서 실시간 확인 가능

  ---

  5. 관련 문서 (Related Docs)
   * JACOCO_SETUP_PLAN.md (./docs/plan/JACOCO_SETUP_PLAN.md)

close #128 