### PR TITLE
 Feat(Build) : JaCoCo 최적화

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,8 @@ jobs:
               DIFF_BASE="HEAD^"
             fi
           fi
-          
-          if git diff --name-only $DIFF_BASE HEAD | grep -E "src/test/|src/androidTest/" > /dev/null; then
+          # 테스트 관련 파일 또는 비즈니스 로직 변경 여부 확인
+          if git diff --name-only $DIFF_BASE HEAD | grep -E "src/main/|src/test/|src/androidTest/" > /dev/null; then
             echo "tests_changed=true" >> $GITHUB_OUTPUT
           else
             echo "tests_changed=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      pages: write      # Pages 배포 권한
+      id-token: write   # OIDC 배포 권한
 
     timeout-minutes: 60
 
@@ -28,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # 변경 사항 확인을 위해 전체 히스토리 가져오기
+          fetch-depth: 0
 
       - name: Check for Test Changes
         id: filter
@@ -37,13 +39,11 @@ jobs:
             DIFF_BASE="origin/${{ github.base_ref }}"
           else
             DIFF_BASE="${{ github.event.before }}"
-            # 첫 푸시거나 이전 커밋 정보를 알 수 없는 경우 대비
             if [ "$DIFF_BASE" == "0000000000000000000000000000000000000000" ]; then
               DIFF_BASE="HEAD^"
             fi
           fi
           
-          # 테스트 관련 파일 변경 여부 확인
           if git diff --name-only $DIFF_BASE HEAD | grep -E "src/test/|src/androidTest/" > /dev/null; then
             echo "tests_changed=true" >> $GITHUB_OUTPUT
           else
@@ -64,11 +64,10 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
-      - name: Check and Build and Test with Coverage
+      - name: Check and Build and Test with JaCoCo
         env:
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-        # 테스트 코드가 변경되었을 때만 jacocoFullReport 실행, 아니면 일반 테스트만 실행
         run: |
           if [ "${{ steps.filter.outputs.tests_changed }}" == "true" ]; then
             ./gradlew spotlessCheck assembleDebug testDebugUnitTest jacocoFullReport --parallel --build-cache --configure-on-demand
@@ -94,7 +93,6 @@ jobs:
           mkdir -p build/dist/badges
           cp -r build/reports/jacoco/jacocoFullReport/html/* build/dist/
           
-          # JSON 배지 데이터 생성 로직
           REPORT_PATH="build/reports/jacoco/jacocoFullReport/jacocoFullReport.xml"
           
           extract_coverage() {
@@ -130,10 +128,13 @@ jobs:
           create_badge_json "Data" $DATA_COV "data"
           create_badge_json "Total" $TOTAL_COV "total"
 
+      - name: Upload Pages Artifact
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && steps.filter.outputs.tests_changed == 'true'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/dist
+
       - name: Deploy to GitHub Pages
         if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && steps.filter.outputs.tests_changed == 'true'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build/dist
-          force_orphan: true # gh-pages 브랜치가 없으면 자동으로 생성함
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -7,6 +7,7 @@ group = "com.gyleedev.build_logic"
 dependencies {
     compileOnly(libs.android.gradle.plugin)
     compileOnly(libs.kotlin.gradle.plugin)
+    compileOnly(libs.jacoco.gradle.plugin)
     compileOnly(libs.hilt.gradle.plugin)
     compileOnly(libs.ksp.gradle.plugin)
     compileOnly(libs.compose.compiler.gradle.plugin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,6 +102,7 @@ fragment = {module = "androidx.fragment:fragment-ktx", version.ref = "fragment"}
 # build-logic dependencies
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+jacoco-gradle-plugin = { group = "org.jacoco", name = "org.jacoco.core", version.ref = "jacoco" }
 hilt-gradle-plugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
 ksp-gradle-plugin = { group = "com.google.devtools.ksp", name = "com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 compose-compiler-gradle-plugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
  1. Changes (주요 변경 사항)

  GitHub Direct Pages Deployment (자원 최적화)
   - 2중 실행 제거: 기존의 gh-pages 브랜치 푸시 방식은 별도의 배포 CI를 트리거하여 자원을 낭비했습니다. 이를 actions/deploy-pages 기반의 직접 배포 방식으로 전환하여 하나의 워크플로우 안에서 모든 배포가 완료되도록 개선
   - 보안 강화: OIDC(id-token: write) 권한을 사용하여 더욱 안전한 배포 환경을 구축

  실시간 JSON 엔드포인트 배지 시스템
   - No Auto-Commit: CI가 README.md를 직접 수정하지 않습니다. 대신 수치 정보가 담긴 작은 JSON 파일을 Pages 서버에 업로드합니다.
   - 실시간 대시보드: Shields.io 엔드포인트 기능을 통해 README.md는 항상 최신 배포된 JSON 데이터를 실시간으로 참조하여 커버리지를 표시합니다. 이를 통해 머지 후 git pull이 불필요한 깔끔한 워크플로우를 완성