### PR TITLE
Refactor(ci): Repository 커버리지 측정 범위를 순수 레포지토리 패키지로 한정

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,10 +160,10 @@ jobs:
                                       stats["uc"]["m"] += int(cnt.get('missed', 0))
                                       stats["uc"]["c"] += int(cnt.get('covered', 0))
                       
-                      # 3. Repository & Meaningful Data Logic (data 패키지)
+                      # 3. Repository (data 패키지 내 repository 키워드 포함)
                       elif "data" in pkg_name:
-                          # 인터셉터, 프리퍼런스, 레포지토리 등 '로직'이 포함된 패키지만 집계
-                          if any(k in pkg_name for k in ["repository", "interceptor", "preference", "datasource"]):
+                          # 배지 이름에 걸맞게 순수 'repository' 로직만 집계
+                          if "repository" in pkg_name:
                               for cnt in pkg.findall('counter'):
                                   if cnt.get('type') == 'INSTRUCTION':
                                       stats["repo"]["m"] += int(cnt.get('missed', 0))


### PR DESCRIPTION
- Repository 배지의 정합성을 위해 preference, interceptor 등을 집계에서 제외
- 실제 Repository 로직에 대한 정확한 지표(약 90% 예상) 회복