### PR TITLE
Fix[Domain] FetchUserUseCase accesstime 관련 문제 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,10 +5,10 @@
 
     <application
         android:name=".GithubSearchApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:enableOnBackInvokedCallback="true"
-        android:fullBackupContent="@xml/backup_rules"
+        android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/data/src/main/java/com/gyleedev/data/repository/GitHubRepositoryImpl.kt
+++ b/data/src/main/java/com/gyleedev/data/repository/GitHubRepositoryImpl.kt
@@ -121,10 +121,6 @@ class GitHubRepositoryImpl @Inject constructor(
             }
         }
 
-    override suspend fun insertUser(userModel: UserModel) {
-        userDao.insertUser(userModel.toEntity())
-    }
-
     // 유닛 테스트 코드 짜봐
     override suspend fun upsertAccessTime(id: Long, githubId: String, isRepoFetched: Boolean) {
         val entity = AccessTimeEntity(

--- a/data/src/test/java/com/gyleedev/data/repository/InsertUserRepositoryImplTest.kt
+++ b/data/src/test/java/com/gyleedev/data/repository/InsertUserRepositoryImplTest.kt
@@ -44,7 +44,7 @@ class InsertUserRepositoryImplTest {
     }
 
     @Test
-    fun `유저 정보를 저장할 때 도메인 모델을 엔티티로 변환하여 UserDao의 insertUser를 호출한다`() = runTest {
+    fun `유저 정보를 저장할 때 도메인 모델을 엔티티로 변환하여 UserDao의 upsertUser를 호출한다`() = runTest {
         // Given
         val userModel = UserModel(
             id = 1L,
@@ -66,13 +66,13 @@ class InsertUserRepositoryImplTest {
         val expectedEntity = userModel.toEntity()
         val expectedInsertId = 100L
 
-        coEvery { userDao.insertUser(expectedEntity) } returns expectedInsertId
+        coEvery { userDao.upsertUser(expectedEntity) } returns expectedInsertId
 
         // When
-        repository.insertUser(userModel)
+        repository.upsertUser(userModel)
 
         // Then
-        coVerify(exactly = 1) { userDao.insertUser(expectedEntity) }
+        coVerify(exactly = 1) { userDao.upsertUser(expectedEntity) }
     }
 
     @Test
@@ -98,12 +98,12 @@ class InsertUserRepositoryImplTest {
         val expectedEntity = userModel.toEntity()
         val exception = RuntimeException("UNIQUE constraint failed: user.github_id")
 
-        coEvery { userDao.insertUser(expectedEntity) } throws exception
+        coEvery { userDao.upsertUser(expectedEntity) } throws exception
 
         // When
         var actualException: Exception? = null
         try {
-            repository.insertUser(userModel)
+            repository.upsertUser(userModel)
             org.junit.Assert.fail("예외가 발생해야 합니다.")
         } catch (e: Exception) {
             actualException = e
@@ -111,6 +111,6 @@ class InsertUserRepositoryImplTest {
 
         // Then
         assertEquals(exception.message, actualException?.message)
-        coVerify(exactly = 1) { userDao.insertUser(expectedEntity) }
+        coVerify(exactly = 1) { userDao.upsertUser(expectedEntity) }
     }
 }

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/repository/GitHubRepository.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/repository/GitHubRepository.kt
@@ -22,8 +22,6 @@ interface GitHubRepository {
 
     suspend fun fetchRepos(id: String): List<RepositoryModel>
 
-    suspend fun insertUser(userModel: UserModel)
-
     suspend fun insertRepositoryList(
         userEntityId: Long,
         list: List<RepositoryModel>,

--- a/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/FetchUserUseCase.kt
+++ b/domain/src/main/java/com/gyleedev/githubsearch/domain/usecase/FetchUserUseCase.kt
@@ -11,8 +11,12 @@ class FetchUserUseCase @Inject constructor(
     suspend operator fun invoke(query: String): SearchStatus = try {
         val result = repository.fetchUser(query)
         if (result is UserFetchResult.Success) {
-            repository.insertUser(result.user)
-            repository.upsertAccessTime(id = 0L, githubId = query, isRepoFetched = false)
+            repository.upsertUser(result.user)
+            repository.upsertAccessTime(
+                id = 0L,
+                githubId = result.user.login,
+                isRepoFetched = false,
+            )
         }
         return when (result) {
             is UserFetchResult.Success -> {

--- a/domain/src/test/java/com/gyleedev/domain/FetchUserUseCaseTest.kt
+++ b/domain/src/test/java/com/gyleedev/domain/FetchUserUseCaseTest.kt
@@ -46,12 +46,13 @@ class FetchUserUseCaseTest {
     fun `검색 결과가 성공일 때 유저 정보를 저장하고 성공 상태를 반환한다`() = runTest {
         // Given
         val query = "android"
+        val expectedId = 0L
         val expectedFetchResult = UserFetchResult.Success(user = userModel)
         val expectedStatus = SearchStatus.SUCCESS
 
         coEvery { repository.fetchUser(query) } returns expectedFetchResult
-        coEvery { repository.insertUser(userModel) } just runs
-        coEvery { repository.upsertAccessTime(id = 0L, githubId = query, isRepoFetched = false) } just runs
+        coEvery { repository.upsertUser(userModel) } returns expectedId
+        coEvery { repository.upsertAccessTime(id = 0L, githubId = userModel.login, isRepoFetched = false) } just runs
 
         // When
         val actual = useCase(query)
@@ -59,19 +60,20 @@ class FetchUserUseCaseTest {
         // Then
         assertEquals(expectedStatus, actual)
         coVerify(exactly = 1) { repository.fetchUser(query) }
-        coVerify(exactly = 1) { repository.insertUser(userModel) }
-        coVerify(exactly = 1) { repository.upsertAccessTime(id = 0L, githubId = query, isRepoFetched = false) }
+        coVerify(exactly = 1) { repository.upsertUser(userModel) }
+        coVerify(exactly = 1) { repository.upsertAccessTime(id = 0L, githubId = userModel.login, isRepoFetched = false) }
     }
 
     @Test
     fun `검색 결과가 존재하지 않는 유저일 때 유효한 실패 상태를 반환한다`() = runTest {
         // Given
         val query = "android"
+        val expectedId = 0L
         val expectedFetchResult = UserFetchResult.NoSuchUser
         val expectedStatus = SearchStatus.NO_SUCH_USER
 
         coEvery { repository.fetchUser(query) } returns expectedFetchResult
-        coEvery { repository.insertUser(any()) } just runs
+        coEvery { repository.upsertUser(any()) } returns expectedId
         coEvery { repository.upsertAccessTime(any(), any(), any()) } just runs
 
         // When
@@ -80,7 +82,7 @@ class FetchUserUseCaseTest {
         // Then
         assertEquals(expectedStatus, actual)
         coVerify(exactly = 1) { repository.fetchUser(query) }
-        coVerify(exactly = 0) { repository.insertUser(any()) }
+        coVerify(exactly = 0) { repository.upsertUser(any()) }
         coVerify(exactly = 0) { repository.upsertAccessTime(any(), any(), any()) }
     }
 
@@ -88,11 +90,12 @@ class FetchUserUseCaseTest {
     fun `할당량이 초과되었을 때 인증 필요 상태를 반환한다`() = runTest {
         // Given
         val query = "android"
+        val expectedId = 0L
         val expectedFetchResult = UserFetchResult.ExceedQuota
         val expectedStatus = SearchStatus.NEED_AUTHENTICATION
 
         coEvery { repository.fetchUser(query) } returns expectedFetchResult
-        coEvery { repository.insertUser(any()) } just runs
+        coEvery { repository.upsertUser(any()) } returns expectedId
         coEvery { repository.upsertAccessTime(any(), any(), any()) } just runs
 
         // When
@@ -101,7 +104,7 @@ class FetchUserUseCaseTest {
         // Then
         assertEquals(expectedStatus, actual)
         coVerify(exactly = 1) { repository.fetchUser(query) }
-        coVerify(exactly = 0) { repository.insertUser(any()) }
+        coVerify(exactly = 0) { repository.upsertUser(any()) }
         coVerify(exactly = 0) { repository.upsertAccessTime(any(), any(), any()) }
     }
 
@@ -109,11 +112,12 @@ class FetchUserUseCaseTest {
     fun `알 수 없는 에러가 발생했을 때 실패 상태를 반환한다`() = runTest {
         // Given
         val query = "android"
+        val expectedId = 0L
         val expectedFetchResult = UserFetchResult.UnknownError
         val expectedStatus = SearchStatus.UNKNOWN_FAIL
 
         coEvery { repository.fetchUser(query) } returns expectedFetchResult
-        coEvery { repository.insertUser(any()) } just runs
+        coEvery { repository.upsertUser(any()) } returns expectedId
         coEvery { repository.upsertAccessTime(any(), any(), any()) } just runs
 
         // When
@@ -122,7 +126,7 @@ class FetchUserUseCaseTest {
         // Then
         assertEquals(expectedStatus, actual)
         coVerify(exactly = 1) { repository.fetchUser(query) }
-        coVerify(exactly = 0) { repository.insertUser(any()) }
+        coVerify(exactly = 0) { repository.upsertUser(any()) }
         coVerify(exactly = 0) { repository.upsertAccessTime(any(), any(), any()) }
     }
 
@@ -130,10 +134,11 @@ class FetchUserUseCaseTest {
     fun `유저 페치 중 예외가 발생하면 네트워크 에러 상태를 반환한다`() = runTest {
         // Given
         val query = "android"
+        val expectedId = 0L
         val expectedStatus = SearchStatus.BAD_NETWORK
 
         coEvery { repository.fetchUser(query) } throws Exception("Unknown Exception")
-        coEvery { repository.insertUser(any()) } just runs
+        coEvery { repository.upsertUser(any()) } returns expectedId
         coEvery { repository.upsertAccessTime(any(), any(), any()) } just runs
 
         // When
@@ -142,7 +147,7 @@ class FetchUserUseCaseTest {
         // Then
         assertEquals(expectedStatus, actual)
         coVerify(exactly = 1) { repository.fetchUser(query) }
-        coVerify(exactly = 0) { repository.insertUser(any()) }
+        coVerify(exactly = 0) { repository.upsertUser(any()) }
         coVerify(exactly = 0) { repository.upsertAccessTime(any(), any(), any()) }
     }
 
@@ -154,7 +159,7 @@ class FetchUserUseCaseTest {
         val expectedStatus = SearchStatus.BAD_NETWORK
 
         coEvery { repository.fetchUser(query) } returns expectedFetchResult
-        coEvery { repository.insertUser(userModel) } throws Exception("DB Exception")
+        coEvery { repository.upsertUser(userModel) } throws Exception("DB Exception")
         coEvery { repository.upsertAccessTime(any(), any(), any()) } just runs
 
         // When
@@ -163,7 +168,7 @@ class FetchUserUseCaseTest {
         // Then
         assertEquals(expectedStatus, actual)
         coVerify(exactly = 1) { repository.fetchUser(query) }
-        coVerify(exactly = 1) { repository.insertUser(userModel) }
+        coVerify(exactly = 1) { repository.upsertUser(userModel) }
         coVerify(exactly = 0) { repository.upsertAccessTime(any(), any(), any()) }
     }
 
@@ -171,11 +176,12 @@ class FetchUserUseCaseTest {
     fun `접근 시간 갱신 중 예외가 발생하면 네트워크 에러 상태를 반환한다`() = runTest {
         // Given
         val query = "android"
+        val expectedId = 0L
         val expectedFetchResult = UserFetchResult.Success(user = userModel)
         val expectedStatus = SearchStatus.BAD_NETWORK
 
         coEvery { repository.fetchUser(query) } returns expectedFetchResult
-        coEvery { repository.insertUser(userModel) } just runs
+        coEvery { repository.upsertUser(userModel) } returns expectedId
         coEvery { repository.upsertAccessTime(any(), any(), any()) } throws Exception("DB Exception")
 
         // When
@@ -184,7 +190,7 @@ class FetchUserUseCaseTest {
         // Then
         assertEquals(expectedStatus, actual)
         coVerify(exactly = 1) { repository.fetchUser(query) }
-        coVerify(exactly = 1) { repository.insertUser(userModel) }
+        coVerify(exactly = 1) { repository.upsertUser(userModel) }
         coVerify(exactly = 1) { repository.upsertAccessTime(any(), any(), any()) }
     }
 }


### PR DESCRIPTION
Problem
  - 특정 유저 검색시 유저 정보는 insert 되는데 repository, accessgtime 이 insert 되지 않는 이슈 발생

Reason
  - insert를 할 때 User 정보는 Response 를 맵핑해서 insert 하는데 AccessTime 에는 userId 대신 검색 Query 를 넣어서 대소문자 구분이 안됐기 때문에 외래키(User,AccessTime) index(github id) 불일치 이슈로 인해서 AccessTime 이 insert가 되지 않는 이슈가 발생함.
  - 이미 존재하는 User 를 Fetch 할 때 Insert 시에 Conflict 가 발생하여 catch 문이 실행이 되어 AccessTime, Repository 가 업데이트 되지 않는 이슈가 발생함

Repository
  - 리포지토리에서 insertUser 를 지우고 upsertUser 로 대체

UseCase
  - Fetch 한 User 를 DB 에 넣을 때 insert 대신 upsert를 사용하여 겹치는게 있더라도 강제로 삽입하고 catch 문으로 빠지지 않고 나머지 동작을 하도록 수정함.
  - upsert User, AccessTime 에서 query 대신 Response 값을 직접 사용하게 하여 외래키 불일치 문제를 해소

ETC
  - AndroidManifest 파일에서 backup 관련 사항을 true->false 로 수정