### PR TITLE
CI 최소 권한 검증 경로 분리

### DIFF
--- a/.codex/agents/compose-ui-reviewer.toml
+++ b/.codex/agents/compose-ui-reviewer.toml
@@ -1,5 +1,6 @@
 name = "compose-ui-reviewer"
 description = "GithubSearch Compose UI reviewer for feature screens, core UI, design system usage, previews, state hoisting, and Material 3 conventions."
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a review-first Codex custom agent for the GithubSearch Android/Kotlin project.
 
@@ -13,8 +14,15 @@ Scope:
 - Focus on Composable responsibility boundaries, Modifier exposure, state hoisting, Preview coverage, Material 3 tokens, WindowInsets, edge-to-edge behavior, accessibility, and screenshot/preview needs.
 - Return concise findings with file references and concrete recommendations.
 
+Output format:
+- Verdict: pass, finding, or insufficient context.
+- Primary-document evidence: path(s) read.
+- Code/test evidence: path(s) read.
+- Findings: severity, impact, and affected path; write "none" when no finding exists.
+- Verification or follow-up and uncertainty.
+
 Guardrails:
-- Review first. Do not edit files unless the parent agent explicitly delegates a bounded write task.
+- This agent is hard read-only. Do not edit files even when the parent asks; return a bounded write recommendation for the main agent or a separate worker.
 - Do not run git add, git commit, git push, or any destructive Git operation.
 - Do not modify or print secrets, local.properties, keystores, signing config, API keys, tokens, passwords, or google-services.json.
 - Report risky changes before suggesting implementation: navigation route changes, public API changes, module dependency changes, Gradle changes, DI graph changes, Room schema/migration changes, large refactors, file deletion, rename/move, or generated file edits.

--- a/.codex/agents/compose-ui-reviewer.toml
+++ b/.codex/agents/compose-ui-reviewer.toml
@@ -5,6 +5,7 @@ You are a review-first Codex custom agent for the GithubSearch Android/Kotlin pr
 
 Source of truth:
 - Follow AGENTS.md and docs/ai/* first.
+- Before concluding, read the relevant primary document and the current affected code or test; return both evidence paths.
 - For Compose/UI work, read docs/ai/UI_GUIDELINES.md, docs/design/DESIGN_GUIDE.md, docs/design/LIQUID_NAVIGATION_GUIDE.md, docs/ai/android-coding-conventions.md, and docs/ai/quality-gates.md.
 
 Scope:

--- a/.codex/agents/compose-ui-reviewer.toml
+++ b/.codex/agents/compose-ui-reviewer.toml
@@ -16,9 +16,10 @@ Scope:
 
 Output format:
 - Verdict: pass, finding, or insufficient context.
+- Review scope: base branch, commit, working-tree diff, or requested files.
 - Primary-document evidence: path(s) read.
 - Code/test evidence: path(s) read.
-- Findings: severity, impact, and affected path; write "none" when no finding exists.
+- Findings: P0/P1/P2 severity, impact, and affected path; write "none" when no finding exists.
 - Verification or follow-up and uncertainty.
 
 Guardrails:

--- a/.codex/agents/data-domain-boundary-guard.toml
+++ b/.codex/agents/data-domain-boundary-guard.toml
@@ -5,6 +5,7 @@ You are a review-first Codex custom agent for the GithubSearch Android/Kotlin pr
 
 Source of truth:
 - Follow AGENTS.md and docs/ai/* first.
+- Before concluding, read the relevant primary document and the current affected code or test; return both evidence paths.
 - For data/domain boundary work, read docs/ARCHITECTURE.md, docs/ai/DATA_LOGIC_GUIDELINES.md, docs/ai/android-coding-conventions.md, docs/ai/task-scope-control.md, and docs/testing/TESTING_GUIDE.md.
 
 Scope:

--- a/.codex/agents/data-domain-boundary-guard.toml
+++ b/.codex/agents/data-domain-boundary-guard.toml
@@ -1,5 +1,6 @@
 name = "data-domain-boundary-guard"
 description = "GithubSearch data/domain boundary reviewer for Repository, UseCase, Room, Retrofit, mapper, data source, and DI impact."
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a review-first Codex custom agent for the GithubSearch Android/Kotlin project.
 
@@ -13,8 +14,15 @@ Scope:
 - Check data/domain boundary violations, domain purity, Entity/Domain separation, mapper usage, Repository public API impact, Room migration risk, and DI graph impact.
 - Identify repository/usecase contract changes that likely need tests, but leave detailed test strategy to test-strategy-reviewer.
 
+Output format:
+- Verdict: pass, finding, or insufficient context.
+- Primary-document evidence: path(s) read.
+- Code/test evidence: path(s) read.
+- Findings: severity, impact, and affected path; write "none" when no finding exists.
+- Verification or follow-up and uncertainty.
+
 Guardrails:
-- Review first. Do not edit files unless the parent agent explicitly delegates a bounded write task.
+- This agent is hard read-only. Do not edit files even when the parent asks; return a bounded write recommendation for the main agent or a separate worker.
 - Do not run git add, git commit, git push, or any destructive Git operation.
 - Do not modify or print secrets, local.properties, keystores, signing config, API keys, tokens, passwords, or google-services.json.
 - Report risky changes before suggesting implementation: navigation route changes, public API changes, module dependency changes, Gradle changes, DI graph changes, Room schema/migration changes, large refactors, file deletion, rename/move, or generated file edits.

--- a/.codex/agents/data-domain-boundary-guard.toml
+++ b/.codex/agents/data-domain-boundary-guard.toml
@@ -16,9 +16,10 @@ Scope:
 
 Output format:
 - Verdict: pass, finding, or insufficient context.
+- Review scope: base branch, commit, working-tree diff, or requested files.
 - Primary-document evidence: path(s) read.
 - Code/test evidence: path(s) read.
-- Findings: severity, impact, and affected path; write "none" when no finding exists.
+- Findings: P0/P1/P2 severity, impact, and affected path; write "none" when no finding exists.
 - Verification or follow-up and uncertainty.
 
 Guardrails:

--- a/.codex/agents/navigation-contract-reviewer.toml
+++ b/.codex/agents/navigation-contract-reviewer.toml
@@ -15,9 +15,10 @@ Scope:
 
 Output format:
 - Verdict: pass, finding, or insufficient context.
+- Review scope: base branch, commit, working-tree diff, or requested files.
 - Primary-document evidence: path(s) read.
 - Code/test evidence: path(s) read.
-- Findings: severity, impact, and affected path; write "none" when no finding exists.
+- Findings: P0/P1/P2 severity, impact, and affected path; write "none" when no finding exists.
 - Verification or follow-up and uncertainty.
 
 Guardrails:

--- a/.codex/agents/navigation-contract-reviewer.toml
+++ b/.codex/agents/navigation-contract-reviewer.toml
@@ -1,5 +1,6 @@
 name = "navigation-contract-reviewer"
 description = "GithubSearch Android/Kotlin navigation reviewer for route contracts, arguments, deep links, back stack, saved state, and screen-transition tests."
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a review-first Codex custom agent for the GithubSearch Android/Kotlin project.
 
@@ -12,8 +13,15 @@ Scope:
 - Review navigation routes, route arguments, deep links, caller/destination compatibility, back stack behavior, saved state restoration, and navigation behavior-test needs.
 - Return concise findings with affected callers, contract risks, verification scenarios, and the primary-document and code/test evidence paths.
 
+Output format:
+- Verdict: pass, finding, or insufficient context.
+- Primary-document evidence: path(s) read.
+- Code/test evidence: path(s) read.
+- Findings: severity, impact, and affected path; write "none" when no finding exists.
+- Verification or follow-up and uncertainty.
+
 Guardrails:
-- Review first. Do not edit files unless the parent agent explicitly delegates a bounded write task.
+- This agent is hard read-only. Do not edit files even when the parent asks; return a bounded write recommendation for the main agent or a separate worker.
 - Do not run git add, git commit, git push, or destructive Git commands.
 - Do not read, print, or modify local.properties, keystores, signing config, API keys, tokens, passwords, or google-services.json.
 - Treat route removal/rename, argument contract changes, deep link changes, public API changes, module dependency changes, Gradle changes, DI changes, Room schema/migration changes, large refactors, file deletion, rename/move, or generated file edits as risky changes.

--- a/.codex/agents/navigation-contract-reviewer.toml
+++ b/.codex/agents/navigation-contract-reviewer.toml
@@ -1,0 +1,21 @@
+name = "navigation-contract-reviewer"
+description = "GithubSearch Android/Kotlin navigation reviewer for route contracts, arguments, deep links, back stack, saved state, and screen-transition tests."
+developer_instructions = """
+You are a review-first Codex custom agent for the GithubSearch Android/Kotlin project.
+
+Source of truth:
+- Follow AGENTS.md and docs/ai/* first.
+- Before concluding, read the relevant primary document and the current affected code or test; return both evidence paths.
+- For navigation work, read docs/ai/navigation-contracts.md, docs/ai/task-scope-control.md, docs/ai/quality-gates.md, and docs/ai/UI_GUIDELINES.md.
+
+Scope:
+- Review navigation routes, route arguments, deep links, caller/destination compatibility, back stack behavior, saved state restoration, and navigation behavior-test needs.
+- Return concise findings with affected callers, contract risks, verification scenarios, and the primary-document and code/test evidence paths.
+
+Guardrails:
+- Review first. Do not edit files unless the parent agent explicitly delegates a bounded write task.
+- Do not run git add, git commit, git push, or destructive Git commands.
+- Do not read, print, or modify local.properties, keystores, signing config, API keys, tokens, passwords, or google-services.json.
+- Treat route removal/rename, argument contract changes, deep link changes, public API changes, module dependency changes, Gradle changes, DI changes, Room schema/migration changes, large refactors, file deletion, rename/move, or generated file edits as risky changes.
+- Do not simplify or remove compatibility paths without explicit approval and rollback consideration.
+"""

--- a/.codex/agents/state-flow-architect.toml
+++ b/.codex/agents/state-flow-architect.toml
@@ -17,9 +17,10 @@ Scope:
 
 Output format:
 - Verdict: pass, finding, or insufficient context.
+- Review scope: base branch, commit, working-tree diff, or requested files.
 - Primary-document evidence: path(s) read.
 - Code/test evidence: path(s) read.
-- Findings: severity, impact, and affected path; write "none" when no finding exists.
+- Findings: P0/P1/P2 severity, impact, and affected path; write "none" when no finding exists.
 - Verification or follow-up and uncertainty.
 
 Guardrails:

--- a/.codex/agents/state-flow-architect.toml
+++ b/.codex/agents/state-flow-architect.toml
@@ -5,6 +5,7 @@ You are a review-first Codex custom agent for the GithubSearch Android/Kotlin pr
 
 Source of truth:
 - Follow AGENTS.md and docs/ai/* first.
+- Before concluding, read the relevant primary document and the current affected code or test; return both evidence paths.
 - For state and logic flow work, read docs/ai/DATA_LOGIC_GUIDELINES.md, docs/ai/android-coding-conventions.md, docs/ai/quality-gates.md, and docs/ai/task-scope-control.md.
 
 Scope:

--- a/.codex/agents/state-flow-architect.toml
+++ b/.codex/agents/state-flow-architect.toml
@@ -1,5 +1,6 @@
 name = "state-flow-architect"
 description = "GithubSearch ViewModel, StateFlow, UiState, Flow, Paging, and UseCase state-flow reviewer."
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a review-first Codex custom agent for the GithubSearch Android/Kotlin project.
 
@@ -14,8 +15,15 @@ Scope:
 - Identify missing or duplicated state transitions, retry paths, error paths, and coroutine scope risks.
 - Note state transitions or error paths that likely need tests, but leave detailed test strategy to test-strategy-reviewer.
 
+Output format:
+- Verdict: pass, finding, or insufficient context.
+- Primary-document evidence: path(s) read.
+- Code/test evidence: path(s) read.
+- Findings: severity, impact, and affected path; write "none" when no finding exists.
+- Verification or follow-up and uncertainty.
+
 Guardrails:
-- Review first. Do not edit files unless the parent agent explicitly delegates a bounded write task.
+- This agent is hard read-only. Do not edit files even when the parent asks; return a bounded write recommendation for the main agent or a separate worker.
 - Do not run git add, git commit, git push, or any destructive Git operation.
 - Do not modify or print secrets, local.properties, keystores, signing config, API keys, tokens, passwords, or google-services.json.
 - Report risky changes before suggesting implementation: navigation route changes, public API changes, module dependency changes, Gradle changes, DI graph changes, Room schema/migration changes, large refactors, file deletion, rename/move, or generated file edits.

--- a/.codex/agents/test-strategy-reviewer.toml
+++ b/.codex/agents/test-strategy-reviewer.toml
@@ -5,6 +5,7 @@ You are a review-first Codex custom agent for the GithubSearch Android/Kotlin pr
 
 Source of truth:
 - Follow AGENTS.md and docs/ai/* first.
+- Before concluding, read the relevant primary document and the current affected code or test; return both evidence paths.
 - For test strategy work, read docs/ai/quality-gates.md, docs/testing/TESTING_GUIDE.md, docs/plan/UNIT_TEST_IMPROVEMENT_PLAN.md, and docs/ai/DATA_LOGIC_GUIDELINES.md.
 
 Scope:

--- a/.codex/agents/test-strategy-reviewer.toml
+++ b/.codex/agents/test-strategy-reviewer.toml
@@ -18,9 +18,10 @@ Scope:
 
 Output format:
 - Verdict: pass, finding, or insufficient context.
+- Review scope: base branch, commit, working-tree diff, or requested files.
 - Primary-document evidence: path(s) read.
 - Code/test evidence: path(s) read.
-- Findings: severity, impact, and affected path; write "none" when no finding exists.
+- Findings: P0/P1/P2 severity, impact, and affected path; write "none" when no finding exists.
 - Verification or follow-up and uncertainty.
 
 Guardrails:

--- a/.codex/agents/test-strategy-reviewer.toml
+++ b/.codex/agents/test-strategy-reviewer.toml
@@ -1,5 +1,6 @@
 name = "test-strategy-reviewer"
 description = "GithubSearch Android/Kotlin test strategy reviewer for JUnit4, MockK, kotlinx-coroutines-test, Flow, ViewModel, Repository, and UseCase tests."
+sandbox_mode = "read-only"
 developer_instructions = """
 You are a review-first Codex custom agent for the GithubSearch Android/Kotlin project.
 
@@ -15,8 +16,15 @@ Scope:
 - Recommend the narrowest Gradle verification command for code changes and explain why.
 - For documentation-only changes, explicitly state that Gradle verification can be skipped when docs/ai/quality-gates.md allows it.
 
+Output format:
+- Verdict: pass, finding, or insufficient context.
+- Primary-document evidence: path(s) read.
+- Code/test evidence: path(s) read.
+- Findings: severity, impact, and affected path; write "none" when no finding exists.
+- Verification or follow-up and uncertainty.
+
 Guardrails:
-- Review first. Do not create or modify test files unless the parent agent explicitly delegates a bounded write task.
+- This agent is hard read-only. Do not create or modify test files even when the parent asks; return a bounded write recommendation for the main agent or a separate worker.
 - Do not run git add, git commit, git push, or any destructive Git operation.
 - Do not modify or print secrets, local.properties, keystores, signing config, API keys, tokens, passwords, or google-services.json.
 - Report risky changes before suggesting implementation: navigation route changes, public API changes, module dependency changes, Gradle changes, DI graph changes, Room schema/migration changes, large refactors, file deletion, rename/move, or generated file edits.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+[agents]
+# Reviewer는 독립적인 읽기 작업만 병렬화한다. main agent는 이 수에 포함되지 않는다.
+max_concurrent_threads_per_session = 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      pull-requests: write
-      pages: write
-      id-token: write
+      contents: read
+
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code_changed }}
 
     timeout-minutes: 60
 
@@ -53,21 +53,6 @@ jobs:
             echo "code_changed=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Validate Secrets
-        if: steps.filter.outputs.code_changed == 'true'
-        env:
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
-        run: |
-          if [ -z "$CLIENT_ID" ]; then
-            echo "::error::CLIENT_ID secret is missing!"
-            exit 1
-          fi
-          if [ -z "$CLIENT_SECRET" ]; then
-            echo "::error::CLIENT_SECRET secret is missing!"
-            exit 1
-          fi
-
       - name: Validate Gradle Wrapper
         if: steps.filter.outputs.code_changed == 'true'
         uses: gradle/actions/wrapper-validation@v4
@@ -82,27 +67,22 @@ jobs:
       - name: Setup Gradle
         if: steps.filter.outputs.code_changed == 'true'
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
       - name: Build and Test with JaCoCo
         if: steps.filter.outputs.code_changed == 'true'
         env:
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+          CLIENT_ID: githubsearch-ci-placeholder
+          CLIENT_SECRET: githubsearch-ci-placeholder
+          REDIRECT_URI: githubsearch://ci
         run: ./gradlew spotlessCheck lintDebug assembleDebug assembleDebugAndroidTest testDebugUnitTest jacocoFullReport --parallel --build-cache --configure-on-demand
 
-      - name: Post JaCoCo Report Comment
-        if: github.event_name == 'pull_request' && steps.filter.outputs.code_changed == 'true'
-        uses: Madrapps/jacoco-report@v1.7.1
+      - name: Upload JaCoCo Report
+        if: steps.filter.outputs.code_changed == 'true'
+        uses: actions/upload-artifact@v4
         with:
-          paths: |
-            ${{ github.workspace }}/build/reports/jacoco/jacocoFullReport/jacocoFullReport.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 0
-          min-coverage-changed-files: 0
-          title: "📈 테스트 커버리지 리포트"
-          update-comment: true
+          name: jacoco-report
+          path: build/reports/jacoco/jacocoFullReport
+          if-no-files-found: error
 
       - name: Prepare Deployment Directory
         if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && steps.filter.outputs.code_changed == 'true'
@@ -214,13 +194,67 @@ jobs:
           ls -R build/dist/badges/
           echo "--------------------------------"
 
-      - name: Upload Pages Artifact
+      - name: Upload Coverage Pages Package
         if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && steps.filter.outputs.code_changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-pages
+          path: build/dist
+          if-no-files-found: error
+
+  coverage-comment:
+    name: "JaCoCo PR Comment"
+    needs: build
+    if: github.event_name == 'pull_request' && needs.build.outputs.code_changed == 'true' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download JaCoCo Report
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/jacocoFullReport
+
+      - name: Post JaCoCo Report Comment
+        uses: Madrapps/jacoco-report@v1.7.1
+        with:
+          paths: |
+            ${{ github.workspace }}/build/reports/jacoco/jacocoFullReport/jacocoFullReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 0
+          min-coverage-changed-files: 0
+          title: "📈 테스트 커버리지 리포트"
+          update-comment: true
+
+  deploy-pages:
+    name: "Deploy Coverage Pages"
+    needs: build
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && needs.build.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Download Coverage Pages Package
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-pages
+          path: build/dist
+
+      - name: Upload Pages Artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: build/dist
 
       - name: Deploy to GitHub Pages
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && steps.filter.outputs.code_changed == 'true'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           if-no-files-found: error
 
       - name: Prepare Deployment Directory
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && steps.filter.outputs.code_changed == 'true'
+        if: github.ref == 'refs/heads/develop' && steps.filter.outputs.code_changed == 'true'
         run: |
           mkdir -p build/dist/badges
           touch build/dist/.nojekyll
@@ -188,14 +188,14 @@ jobs:
           EOF
 
       - name: Verify Artifacts
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && steps.filter.outputs.code_changed == 'true'
+        if: github.ref == 'refs/heads/develop' && steps.filter.outputs.code_changed == 'true'
         run: |
           echo "--- Checking Generated Badges ---"
           ls -R build/dist/badges/
           echo "--------------------------------"
 
       - name: Upload Coverage Pages Package
-        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && steps.filter.outputs.code_changed == 'true'
+        if: github.ref == 'refs/heads/develop' && steps.filter.outputs.code_changed == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-pages
@@ -232,7 +232,7 @@ jobs:
   deploy-pages:
     name: "Deploy Coverage Pages"
     needs: build
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop') && needs.build.outputs.code_changed == 'true'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.build.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
 
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,13 @@ Kotlin/Android 코드 작성 규칙의 source of truth는 `docs/ai/android-codin
 
 코드 수정 작업은 `docs/ai/quality-gates.md`의 검증 규칙을 따른다. 문서-only 변경은 Gradle 검증을 생략할 수 있다.
 
+## Worktree와 Local 환경
+
+Codex App worktree의 secret-free 검증 범위, Local handoff 조건, branch 중복 checkout 제한, `.worktreeinclude` 예외 절차는 `docs/ai/worktree-policy.md`를 따른다.
+
+- 현재 ignore된 `local.properties`와 keystore, token, `google-services.json`은 worktree에 복사하거나 `.worktreeinclude`에 등록하지 않는다.
+- 실제 OAuth·기기·signing·machine-specific 검증은 Local handoff로 분리한다.
+
 ## Screenshot Test Strategy
 
 Compose screenshot test의 도입 상태, 대상 module, fixture 분리, golden·CI 규칙은 `docs/testing/TESTING_GUIDE.md`와 `docs/testing/SCREENSHOT_TEST_IMPLEMENTATION_PLAN.md`를 source of truth로 둔다. Gradle plugin/dependency, source set, CI 변경은 Risky Change이므로 계획의 Phase 1 전에는 사용자 승인을 받는다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,10 @@ Codex App worktree의 secret-free 검증 범위, Local handoff 조건, branch �
 - 현재 ignore된 `local.properties`와 keystore, token, `google-services.json`은 worktree에 복사하거나 `.worktreeinclude`에 등록하지 않는다.
 - 실제 OAuth·기기·signing·machine-specific 검증은 Local handoff로 분리한다.
 
+## Code Review
+
+custom reviewer, Codex `/review`, 사람 PR review의 scope 선언, P0~P2 severity, evidence, test-gap, lifecycle hook 경계는 `docs/ai/code-review.md`를 따른다. style 선호만으로 finding을 만들지 않으며, 최종 적용·검증·merge 판단은 main agent 또는 사람이 소유한다.
+
 ## Screenshot Test Strategy
 
 Compose screenshot test의 도입 상태, 대상 module, fixture 분리, golden·CI 규칙은 `docs/testing/TESTING_GUIDE.md`와 `docs/testing/SCREENSHOT_TEST_IMPLEMENTATION_PLAN.md`를 source of truth로 둔다. Gradle plugin/dependency, source set, CI 변경은 Risky Change이므로 계획의 Phase 1 전에는 사용자 승인을 받는다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,15 @@ Screenshot test 도입 후의 module별 `updateDebugScreenshotTest`·`validateDe
 
 단순 질의와 짧은 상태 응답을 제외한 모든 project 작업은 시작 시 `project-knowledge-grounding`을 적용한다. 파일을 수정하는 모든 project 작업은 종료 전에 `session-retrospective`를 적용해 작업 이력, generated Index, 지식 관계 검증과 Change Report를 함께 점검한다.
 
+## Custom Agent Delegation
+
+custom agent의 역할·필수 문서·운영 계약은 `docs/ai/subagents.md`와 `docs/ai/registry/agents.toml`을 따른다.
+
+- custom agent는 사용자가 명시적으로 요청했거나, 현재 workflow가 독립적인 검토가 필요하다고 정한 경우에만 호출한다.
+- reviewer는 hard read-only다. 구현은 main agent가 직접 수행하거나, main agent가 명시한 제한된 write scope의 별도 worker만 수행한다.
+- Small 변경은 기본적으로 main agent만 사용한다. 독립적인 read-only 조사·검토는 최대 3개까지 병렬화할 수 있으며, 같은 파일 또는 같은 동작을 수정하는 작업은 한 명만 write 담당으로 둔다.
+- main agent는 subagent 결과를 검토·통합하고, 위험 판단·최종 적용·검증·Change Report 책임을 유지한다.
+
 ## Coding Conventions
 
 Kotlin/Android 코드 작성 규칙의 source of truth는 `docs/ai/android-coding-conventions.md`다. 기존 프로젝트 custom docs도 함께 보존한다.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -36,7 +36,8 @@
 - `android-coding-conventions.md`: Kotlin/Android 코드 작성 규칙과 commit convention.
 - `change-report-template.md`: 최종 응답, 커밋 메시지, PR 설명 재사용 형식.
 - `template-sync-policy.md`: skill template과 project docs 간 sync 정책.
-- `subagents.md`: GithubSearch에서 단계적으로 사용할 Codex subagent 4개 역할과 운영 규칙 초안.
+- `subagents.md`: GithubSearch에서 실제 운영하는 Codex custom agent 5개 역할과 공통 근거·권한·위험 변경 규칙.
+- `navigation-contracts.md`: 현재 Compose navigation의 route, argument, 호출자, back stack, 상태 복원 계약 정본.
 - `reporting-system-migration-plan.md`: SmartTimer식 보고·작업 이력·지식 운영 체계의 GithubSearch 이식 범위와 phase별 exit gate.
 - `knowledge-governance-enforcement-plan.md`: local document 분리, graph verifier 확대, AI 절차·hook·별도 CI 강제의 후속 실행 명세.
 - `knowledge-governance-enforcement-prompt.md`: 위 실행 명세를 구현할 때 사용하는 제약 포함 실행 프롬프트.

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -41,6 +41,7 @@
 - `reporting-system-migration-plan.md`: SmartTimer식 보고·작업 이력·지식 운영 체계의 GithubSearch 이식 범위와 phase별 exit gate.
 - `knowledge-governance-enforcement-plan.md`: local document 분리, graph verifier 확대, AI 절차·hook·별도 CI 강제의 후속 실행 명세.
 - `knowledge-governance-enforcement-prompt.md`: 위 실행 명세를 구현할 때 사용하는 제약 포함 실행 프롬프트.
+- `codex-operation-hardening-plan.md`: 공식 Codex 가이드에 근거한 agent 권한, CI 최소 권한, worktree, review 운영 보강의 단계별 실행 명세.
 - `knowledge-operations.md`: 문서·코드 근거, 작업 이력, project skill·agent 배선, 세션 회고 규칙.
 - `SKILLS_CATALOG.md`: project skill의 trigger와 경계.
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -42,6 +42,8 @@
 - `knowledge-governance-enforcement-plan.md`: local document 분리, graph verifier 확대, AI 절차·hook·별도 CI 강제의 후속 실행 명세.
 - `knowledge-governance-enforcement-prompt.md`: 위 실행 명세를 구현할 때 사용하는 제약 포함 실행 프롬프트.
 - `codex-operation-hardening-plan.md`: 공식 Codex 가이드에 근거한 agent 권한, CI 최소 권한, worktree, review 운영 보강의 단계별 실행 명세.
+- `cross-project-operation-principles-template.md`: Phase 0~2 결과를 바탕으로 다른 repository 도입 시 재사용할 원칙과 project-specific 조정 항목을 구분한 provisional template.
+- `worktree-policy.md`: Codex App worktree의 secret-free 검증 범위, Local handoff, branch 제한, `.worktreeinclude` 예외를 정의하는 GithubSearch 적용 정책.
 - `knowledge-operations.md`: 문서·코드 근거, 작업 이력, project skill·agent 배선, 세션 회고 규칙.
 - `SKILLS_CATALOG.md`: project skill의 trigger와 경계.
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -44,6 +44,7 @@
 - `codex-operation-hardening-plan.md`: 공식 Codex 가이드에 근거한 agent 권한, CI 최소 권한, worktree, review 운영 보강의 단계별 실행 명세.
 - `cross-project-operation-principles-template.md`: Phase 0~2 결과를 바탕으로 다른 repository 도입 시 재사용할 원칙과 project-specific 조정 항목을 구분한 provisional template.
 - `worktree-policy.md`: Codex App worktree의 secret-free 검증 범위, Local handoff, branch 제한, `.worktreeinclude` 예외를 정의하는 GithubSearch 적용 정책.
+- `code-review.md`: custom reviewer, `/review`, 사람 PR review의 scope, P0~P2 finding, evidence, test-gap, lifecycle hook 경계를 정의하는 공통 기준.
 - `knowledge-operations.md`: 문서·코드 근거, 작업 이력, project skill·agent 배선, 세션 회고 규칙.
 - `SKILLS_CATALOG.md`: project skill의 trigger와 경계.
 

--- a/docs/ai/code-review.md
+++ b/docs/ai/code-review.md
@@ -1,0 +1,73 @@
+# Code Review 기준과 Hook 경계
+
+이 문서는 GithubSearch의 custom reviewer, Codex `/review`, 사람 PR review가 공유하는 결과 기준이다. 코드 작성 규칙은 `android-coding-conventions.md`, 검증 명령은 `quality-gates.md`, 위험 범위는 `task-scope-control.md`를 따른다.
+
+## Review 시작 전 범위 선언
+
+review 요청은 아래 중 하나로 범위를 명시한다. 범위가 없으면 reviewer는 추측으로 전체 repository를 검토하지 않고 필요한 base 또는 diff를 요청한다.
+
+- base branch 대비 현재 diff
+- 특정 commit
+- 현재 working tree의 unstaged/staged diff
+- 요청자가 지정한 파일 또는 동작
+
+reviewer는 관련 primary document와 영향을 받는 코드 또는 테스트를 함께 읽고, 두 경로를 결과에 남긴다.
+
+## Finding 우선순위
+
+| 심각도 | 의미 | 예시 |
+| --- | --- | --- |
+| P0 | merge 전 반드시 막아야 하는 문제 | 데이터 손상·secret 노출·앱 실행 불가·보안 우회 |
+| P1 | 다음 수정에서 반드시 해결해야 할 실제 동작 회귀 | navigation 계약 위반·잘못된 상태 전이·crash 가능성·API 계약 불일치 |
+| P2 | 배포를 막지는 않지만 근거가 있는 품질·검증 공백 | 재현 가능한 접근성 문제·필요한 test 누락·명확한 유지보수 위험 |
+
+단순 코드 스타일 선호, 대안 구현 취향, 현재 규칙으로 뒷받침되지 않는 제안은 finding으로 보고하지 않는다. 필요하면 `non-blocking note` 또는 `question`으로 구분한다.
+
+## Finding 형식
+
+각 finding에는 아래를 모두 포함한다.
+
+```text
+Severity: P0 | P1 | P2
+Impact: 사용자·데이터·보안·계약에 미치는 실제 영향
+Evidence: 재현 조건 또는 관련 문서·코드·테스트 경로
+Affected path: <file path>
+Minimum action: 가장 작은 수정 또는 검증 방법
+```
+
+- 실제 회귀를 재현할 수 없고 근거도 부족하면 `insufficient context`로 보고한다.
+- 기존 동작이 의도된 것으로 확인되면 finding을 철회하고 이유를 남긴다.
+- test gap은 기능 결함으로 단정하지 않는다. 어떤 동작이 검증되지 않았는지, 우선순위와 최소 검증 방법을 P2 또는 follow-up으로 기록한다.
+
+## 공통 결과 형식
+
+custom reviewer와 사람 또는 `/review` 결과는 다음 정보를 같은 순서로 제공한다.
+
+```text
+Verdict: pass | finding | insufficient context
+Review scope: base branch | commit | working-tree diff | requested files
+Primary-document evidence: <path(s)>
+Code/test evidence: <path(s)>
+Findings: <P0/P1/P2 finding(s), or none>
+Verification or follow-up: <minimum action>
+Uncertainty: <none or missing evidence>
+```
+
+custom reviewer는 read-only이며 결과가 `pass`여도 main agent 또는 사람이 최종 적용·검증·merge 판단을 소유한다.
+
+## Lifecycle Hook·Git Hook·CI 경계
+
+| 계층 | 책임 | 이 Phase의 상태 |
+| --- | --- | --- |
+| Git pre-commit hook | staged 지식 변경, resource lint처럼 commit 시점에 빠르게 확인 가능한 항목 | 유지 |
+| Knowledge CI | PR에서 Index·graph 관계를 독립적으로 확인 | 유지 |
+| Build CI | compile·lint·test와 job별 권한 검증 | 유지 |
+| Codex lifecycle hook | 세션·도구 사용 주기의 보조 안내 또는 제한 | 이번 Phase에서는 추가하지 않음 |
+
+Codex lifecycle hook은 같은 검사를 반복하는 수단이 아니다. formatter, Index, graph verifier처럼 이미 Git hook 또는 CI가 강제하는 검사를 lifecycle hook으로 중복하지 않는다.
+
+`SessionStart` 또는 `Stop` hook은 실제 작업 이력에서 같은 누락이 반복될 때만 별도 Small/Medium 작업으로 제안한다. 도입 시에는 hook의 신뢰 검토, timeout, 실행 범위, secret 출력 금지, 파일·stage·commit 미수정, rollback을 명시한다.
+
+## 대표 확인과 후속 회고
+
+Phase 1에서 `compose-ui-reviewer`가 문서 근거, 코드 근거, finding, 최소 후속 조치를 반환한 runtime 확인 결과를 이 공통 형식의 대표 사례로 사용한다. Phase 5에서는 실제 PR review 3~5건을 다시 살펴 severity 일관성, false-positive 비율, test-gap 품질, lifecycle hook 필요성을 회고한다.

--- a/docs/ai/codex-operation-hardening-plan.md
+++ b/docs/ai/codex-operation-hardening-plan.md
@@ -1,6 +1,6 @@
 # Codex 운영 정책 보강 명세
 
-> **Status:** active — Phase 0 and Phase 1 completed, Phase 2 pending
+> **Status:** active — Phase 0~3 completed, Phase 4~5 planned
 >
 > **Purpose:** GithubSearch의 Codex 운영 정책을 공식 Codex 가이드의 durable guidance, bounded subagent, 최소 권한, worktree 안전성 원칙에 맞춰 단계적으로 보강한다.
 >
@@ -17,8 +17,8 @@
 | Codex session 기본값 | 사용자 전역 config, project `.codex/config.toml` | reviewer 최대 병렬 수 3 적용 | 유지 |
 | staged 변경 검사 | `.githooks/pre-commit` | 운영 중, clone/worktree별 설치 필요 | 유지 |
 | 문서·agent 지식 관계 | registry, generated Index, `knowledge.yml` | 운영 중, read-only CI | 유지 |
-| Android build·coverage·배포 권한 | `build.yml`, 저장소 관리자 | 한 job에 혼재 | Phase 2에서 verify/comment/deploy 분리 |
-| worktree local 설정·기기 검증 | 사용자 Local 환경 | 정책 문서 없음 | Phase 3에서 문서화 |
+| Android build·coverage·배포 권한 | `build.yml`, 저장소 관리자 | verify/comment/deploy 분리, 원격 PR 검증 완료 | Phase 5에서 required status 확인 |
+| worktree local 설정·기기 검증 | `worktree-policy.md`, 사용자 Local 환경 | secret 미복사·Local handoff 경계 문서화 | Phase 5에서 반복 적용 회고 |
 | branch protection·required status | 저장소 관리자 | 외부 설정 | Phase 5에서 관리자 확인 |
 
 이 분리는 다음 경계를 고정한다.
@@ -207,15 +207,21 @@ Uncertainty: <none or missing evidence>
 
 ### 체크리스트
 
-- [ ] worktree 생성, Local handoff, branch 중복 checkout 제한을 문서화한다.
-- [ ] ignore 파일을 복사하지 않는 기본값과 필요한 수동 준비 항목을 문서화한다.
-- [ ] `.worktreeinclude`를 추가하려면 대상 파일이 credential을 포함하지 않는다는 저장소 관리자 검토를 기록한다.
-- [ ] 새 worktree에서 문서·unit/compile 검증 가능 범위와 Local 전용 검증 범위를 분리한다.
+- [x] worktree 생성, Local handoff, branch 중복 checkout 제한을 문서화한다.
+- [x] ignore 파일을 복사하지 않는 기본값과 필요한 수동 준비 항목을 문서화한다.
+- [x] `.worktreeinclude`를 추가하지 않았고, 미래 예외에는 credential-free 대상의 저장소 관리자 검토와 작업 이력을 요구한다.
+- [x] 새 worktree에서 문서·unit/compile 검증 가능 범위와 Local 전용 검증 범위를 분리한다.
 
 ### Exit gate
 
 - worktree 문서가 secret 복사를 지시하지 않는다.
 - 새 worktree에서 가능한 검증과 handoff 조건이 명확하다.
+
+### Phase 3 실행 결과
+
+- `.worktreeinclude`를 추가하지 않았다. `local.properties`의 내용은 읽거나 복사하지 않았으며, SDK와 credential이 함께 있을 수 있는 ignore 파일로 취급한다.
+- `worktree-policy.md`에 secret-free worktree 범위, Android SDK 준비 실패 시의 Local handoff, 실제 OAuth·기기·signing 검증의 Local 전용 경계를 기록했다.
+- Git branch의 checkout 제한과 Codex App Handoff 사용 기준을 문서화했다.
 
 ## Phase 4 — 공통 code review 기준과 lifecycle hook 경계
 

--- a/docs/ai/codex-operation-hardening-plan.md
+++ b/docs/ai/codex-operation-hardening-plan.md
@@ -1,6 +1,6 @@
 # Codex 운영 정책 보강 명세
 
-> **Status:** active — Phase 0~4 completed, Phase 5 planned
+> **Status:** active — Phase 0~4 completed, Phase 5 in progress
 >
 > **Purpose:** GithubSearch의 Codex 운영 정책을 공식 Codex 가이드의 durable guidance, bounded subagent, 최소 권한, worktree 안전성 원칙에 맞춰 단계적으로 보강한다.
 >
@@ -19,7 +19,7 @@
 | 문서·agent 지식 관계 | registry, generated Index, `knowledge.yml` | 운영 중, read-only CI | 유지 |
 | Android build·coverage·배포 권한 | `build.yml`, 저장소 관리자 | verify/comment/deploy 분리, 원격 PR 검증 완료 | Phase 5에서 required status 확인 |
 | worktree local 설정·기기 검증 | `worktree-policy.md`, 사용자 Local 환경 | secret 미복사·Local handoff 경계 문서화 | Phase 5에서 반복 적용 회고 |
-| branch protection·required status | 저장소 관리자 | 외부 설정 | Phase 5에서 관리자 확인 |
+| branch protection·required status | 저장소 관리자 | `develop` branch protection·required status 미설정 확인 | Phase 5 관리자 설정 대기 |
 
 이 분리는 다음 경계를 고정한다.
 
@@ -285,6 +285,14 @@ Uncertainty: <none or missing evidence>
 
 - 최소 세 번의 Medium 이상 작업에서 policy를 적용하고, 결과가 history와 Change Report에 남아 있다.
 - CI 권한·secret 노출·worktree secret 복사·parallel write 충돌이 없음을 확인한다.
+
+### Phase 5 현재 상태
+
+- Phase 0~4는 독립 commit과 completed history record를 갖는다. Phase 2의 draft PR #161은 Build·Knowledge·coverage comment 성공과 Pages deploy skip을 확인했다.
+- PR #161의 remote head는 아직 `b6bba07`이며, Phase 3·4 commit은 local branch에만 있다. push 후 PR CI를 다시 확인해야 한다.
+- `develop`은 현재 branch protection이 없어 required status가 지정되지 않았다. 이는 저장소 관리자만 변경한다.
+- `github-pages` environment에는 branch policy가 있으나 protected branch 전용은 아니다. Pages 권한·배포 branch 정책은 관리자 확인이 필요하다.
+- 실제 Codex managed worktree의 Android 검증·Local handoff 반복 사례와 review 품질 3~5건 회고는 아직 부족하다.
 
 ## 적용 순서와 승인 경계
 

--- a/docs/ai/codex-operation-hardening-plan.md
+++ b/docs/ai/codex-operation-hardening-plan.md
@@ -1,0 +1,290 @@
+# Codex 운영 정책 보강 명세
+
+> **Status:** active — Phase 0 completed, Phase 1 pending
+>
+> **Purpose:** GithubSearch의 Codex 운영 정책을 공식 Codex 가이드의 durable guidance, bounded subagent, 최소 권한, worktree 안전성 원칙에 맞춰 단계적으로 보강한다.
+>
+> **Scope:** custom agent, project Codex 설정, review 기준, GitHub Actions 권한, worktree 운영 문서. 앱 기능, navigation 동작, Gradle 의존성, OAuth 동작은 이 명세만으로 변경하지 않는다.
+
+## 운영 상태와 책임 분리
+
+이 명세에서 **완료된 Phase 0의 결정**과 **아직 적용하지 않은 후속 phase의 구현**을 구분한다. 현재 runtime 규칙은 `AGENTS.md`, `docs/ai/subagents.md`, `.codex/agents/*.toml`이 정본이며, Phase 1~4의 항목은 해당 phase가 완료될 때까지 현재 동작을 바꾸지 않는다.
+
+| 책임 영역 | 정본·담당 | 현재 상태 | 다음 변경 phase |
+| --- | --- | --- | --- |
+| 작업 범위·최종 판단·보고 | main agent, `AGENTS.md`, `knowledge-operations.md` | 운영 중 | 유지 |
+| reviewer 역할·근거·write 권한 | `.codex/agents/*.toml`, `subagents.md` | 정책상 review-first | Phase 1에서 hard read-only로 강제 |
+| Codex session 기본값 | 사용자 전역 config, project `.codex/config.toml` | project config 없음 | Phase 1에서 project 불변값만 추가 |
+| staged 변경 검사 | `.githooks/pre-commit` | 운영 중, clone/worktree별 설치 필요 | 유지 |
+| 문서·agent 지식 관계 | registry, generated Index, `knowledge.yml` | 운영 중, read-only CI | 유지 |
+| Android build·coverage·배포 권한 | `build.yml`, 저장소 관리자 | 한 job에 혼재 | Phase 2에서 verify/comment/deploy 분리 |
+| worktree local 설정·기기 검증 | 사용자 Local 환경 | 정책 문서 없음 | Phase 3에서 문서화 |
+| branch protection·required status | 저장소 관리자 | 외부 설정 | Phase 5에서 관리자 확인 |
+
+이 분리는 다음 경계를 고정한다.
+
+- main agent와 reviewer의 책임은 즉시 분리한다. Phase 1 전까지 reviewer의 현재 제한된 write 예외는 유지되지만, main agent가 write scope·최종 적용·검증을 계속 소유한다.
+- project repository는 팀 공통 불변값만 보관한다. 모델·reasoning·개인 connector·승인 설정은 사용자 전역 config에 남긴다.
+- Git hook은 commit 시점, `knowledge.yml`은 PR 시점, 향후 Codex lifecycle hook은 세션 시점을 담당한다. 동일 검사를 여러 계층에 복제하지 않는다.
+- CI 권한, OAuth secret, Pages 배포, branch protection은 repository 관리자와 명시적 Risky Change 승인 없이는 변경하지 않는다.
+
+## 근거와 운영 원칙
+
+- Codex는 repository 규칙을 `AGENTS.md`에 두고, 반복 작업은 skill·hook·CI로 옮기며, 독립적인 읽기 작업만 subagent로 병렬화할 것을 권장한다. [Best practices](https://learn.chatgpt.com/guides/best-practices.md)
+- custom agent는 프로젝트 `.codex/agents/`에서 역할별 지시와 sandbox를 가질 수 있다. 읽기 중심 검토는 read-only agent가 적합하며, 병렬 쓰기는 충돌 위험 때문에 피한다. [Subagents](https://learn.chatgpt.com/docs/agent-configuration/subagents.md)
+- Codex worktree는 ignore 파일을 기본 복사하지 않는다. 민감한 local 설정을 복사하기 전에 명시적인 보안 판단이 필요하다. [Worktrees](https://learn.chatgpt.com/docs/environments/git-worktrees.md)
+- Codex hook은 세션과 도구 사용 주기에 연결되고, Git hook은 commit 시점 검사다. 두 수단은 목적이 다르므로 같은 검사를 중복시키지 않는다. [Hooks](https://learn.chatgpt.com/docs/hooks.md)
+
+이 명세의 기본 원칙은 다음과 같다.
+
+1. **정책과 강제를 분리한다.** `AGENTS.md`와 문서는 판단 기준을, agent sandbox·Git hook·CI는 기계적으로 확인 가능한 최소 규칙을 담당한다.
+2. **권한은 가장 작게 부여한다.** 검토 agent와 검증 CI는 read-only를 기본으로 하고, 쓰기·배포·PR 댓글 권한은 필요한 분리 job에만 둔다.
+3. **main agent가 책임진다.** subagent는 독립된 근거 수집·검토만 수행하며, 위험 판단·수정·검증 선택·최종 보고는 main agent가 맡는다.
+4. **secret을 검증 입력으로 쓰지 않는다.** PR build는 production OAuth 값 없이 compile·test할 수 있어야 하며, `pull_request_target`로 이 문제를 우회하지 않는다.
+5. **정책 phase는 한 번에 하나만 적용한다.** 각 phase의 exit gate가 통과하고 필요한 저장소 관리자 승인이 끝난 뒤 다음 phase로 진행한다.
+
+## 현재 기준선
+
+| 영역 | 현재 상태 | 유지할 점 | 보강 필요 |
+| --- | --- | --- | --- |
+| durable guidance | `AGENTS.md`와 `docs/ai/*`가 역할·검증·위험 변경을 정의 | 6.3KB의 간결한 root 지시와 주제별 분리 | 실제 권한 강제와 reviewer 결과 형식 |
+| custom agent | 5개 reviewer와 registry·근거 경로 반환 규칙 존재 | review-first, Git·secret 금지, parent 책임 | technical read-only, 병렬 위임 판단 기준 |
+| Git hook·knowledge CI | staged guard와 `contents: read` knowledge CI 존재 | 생성 Index·graph 관계 검사 | 새 clone/worktree 설치 안내와 Codex lifecycle hook의 경계 |
+| build CI | build·coverage·PR comment·Pages 배포가 하나의 job에 있음 | build/knowledge workflow 분리 | job별 최소 권한과 production OAuth secret 제거 |
+| worktree | Git worktree 사용 가능 | Git branch 충돌 방지 | ignore된 `local.properties`의 안전한 처리 정책 |
+| review | 역할별 reviewer는 존재 | 파일·근거 중심 검토 | 공통 심각도와 `/review` 결과 기준 |
+
+## Phase 0 — 결정 고정과 기준선 검사
+
+**목적:** 뒤 phase가 서로 다른 권한 모델을 만들지 않도록 보안·운영 결정을 먼저 고정한다. 이 phase는 문서와 검사만 바꾸며 CI 또는 agent 권한을 바꾸지 않는다.
+
+### 수정 대상
+
+- `docs/ai/codex-operation-hardening-plan.md` (이 명세)
+- `docs/ai/README.md`
+- `docs/ai/registry/documents.toml`
+- `docs/history/records/YYYY/`
+
+### 확정할 결정
+
+- reviewer agent는 hard read-only로 고정하고, 파일 수정은 main agent 또는 별도 worker에게만 맡긴다.
+- project `.codex/config.toml`에는 project 불변값만 둔다. 개인 모델, reasoning, connector, 승인 설정은 사용자 전역 config에 남긴다.
+- worktree에는 `local.properties`, keystore, OAuth 값 등 ignore된 설정을 기본 복사하지 않는다.
+- CI build는 production OAuth secret 없이 실행 가능하도록 바꾸며, `pull_request_target`은 사용하지 않는다.
+
+### 체크리스트
+
+- [x] 현재 `.codex/agents/*.toml`, `.githooks/pre-commit`, `build.yml`, `knowledge.yml`의 기준선과 담당자를 record에 남긴다.
+- [x] `local.properties`의 **내용을 읽거나 기록하지 않고**, 파일이 ignore된 local 설정임만 확인한다.
+- [x] Phase 1~4가 기존 기능 route, Gradle dependency, OAuth 동작을 바꾸지 않는지 확인한다.
+- [x] branch protection과 GitHub Actions 권한 변경은 저장소 관리자 승인 항목으로 분리한다.
+
+### Exit gate
+
+- 문서 registry, generated Index, graph verifier가 통과한다.
+- 사용자 local 파일을 수정·stage·commit하지 않는다.
+
+### Phase 0 실행 결과
+
+- reviewer hard read-only, project/user config 경계, worktree secret 미복사, CI secret 제거 목표를 후속 구현 전에 확정했다.
+- Phase 1의 agent sandbox 변경, Phase 2의 CI 권한·secret 변경, Phase 3의 worktree 문서는 아직 적용하지 않았다.
+- 이 phase는 문서·정책 경계만 변경하므로 앱 code, route, Gradle dependency, OAuth 동작에는 영향이 없다.
+
+## Phase 1 — Reviewer 권한과 subagent 위임 정책
+
+**목적:** “review-first·기본 read-only”를 자연어 약속에서 실제 실행 권한과 일관된 결과 형식으로 올린다.
+
+### 수정 대상
+
+- `.codex/config.toml` (신규)
+- `.codex/agents/{compose-ui-reviewer,data-domain-boundary-guard,navigation-contract-reviewer,state-flow-architect,test-strategy-reviewer}.toml`
+- `docs/ai/subagents.md`
+- `docs/ai/registry/agents.toml`
+- `AGENTS.md`
+
+### 적용 정책
+
+1. 다섯 reviewer TOML에 `sandbox_mode = "read-only"`를 명시한다. reviewer는 parent가 요청해도 파일을 직접 수정하지 않는다.
+2. 구현이 필요하면 main agent가 수정하거나, 작업별로 명시적인 write scope를 받은 `worker` 역할을 별도 호출한다. reviewer 역할을 쓰기 전용 worker로 바꾸지 않는다.
+3. project config의 `[agents]`에는 `max_concurrent_threads_per_session = 3`만 둔다. 모델·reasoning은 현재처럼 parent/user 설정을 상속하며 repository에 고정하지 않는다.
+4. 병렬 위임은 독립적인 read-heavy 조사·테스트 전략·로그 분석에만 사용한다. 동일 파일 또는 하나의 동작을 수정하는 작업은 한 명만 write 담당으로 둔다.
+5. custom agent 결과는 아래 형식을 사용한다.
+
+```text
+Verdict: <pass / finding / insufficient context>
+Primary-document evidence: <path>
+Code/test evidence: <path>
+Findings: <severity, impact, affected path>
+Verification or follow-up: <minimum action>
+Uncertainty: <none or missing evidence>
+```
+
+### 체크리스트
+
+- [ ] 모든 reviewer TOML의 name, description, scope, required documents가 registry와 일치한다.
+- [ ] 모든 reviewer가 read-only sandbox, Git 금지, secret 금지, 위험 변경 보고, 근거 경로 반환을 가진다.
+- [ ] `subagents.md`에 Small 변경은 single agent, 독립 read-only 검토는 최대 3개 병렬, write는 1명이라는 dispatcher 표를 추가한다.
+- [ ] `AGENTS.md`에 “명시적 요청 또는 project workflow가 정한 경우에만 subagent 위임” 원칙을 추가한다.
+- [ ] reviewer가 답변만 하고 파일을 수정하지 않는 수동 확인을 한 번 기록한다.
+
+### Exit gate
+
+- `python3 scripts/ai/generate_knowledge_index.py --check`
+- `python3 scripts/ai/verify_knowledge_graph.py`
+- agent TOML 경로·ID·required document 관계 검사 통과
+- main agent가 reviewer 결과를 합쳐 최종 판단·검증·보고를 작성한 예시 1건 확인
+
+## Phase 2 — Build CI 최소 권한과 secret 없는 검증
+
+**목적:** PR의 임의 코드가 production OAuth credential 또는 Pages 배포 권한을 가진 job에서 실행되지 않게 한다.
+
+### 수정 대상
+
+- `.github/workflows/build.yml`
+- 필요 시 `.github/workflows/coverage-comment.yml` 또는 `build.yml`의 분리 job
+- 필요 시 `docs/ai/quality-gates.md`, `docs/ai/README.md`
+- 필요 시 CI placeholder 전달을 위한 build logic 또는 Gradle test 설정
+
+### 적용 정책
+
+1. compile·lint·test job은 `permissions: { contents: read }`만 가진다.
+2. PR build에는 production `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`, cache encryption secret을 주입하지 않는다. 현재 `getApiKey`가 이 값을 요구하므로 먼저 비밀이 아닌 고정 CI placeholder로 전체 Gradle 검증이 되는지 확인한다.
+3. JaCoCo PR 댓글을 유지한다면 별도 job으로 분리해 `pull-requests: write`만 준다. fork PR에서는 댓글 job을 실행하지 않는다.
+4. Pages upload·deploy는 `main`·`develop` push 전용 별도 job으로 분리해 그 job에만 `pages: write`, `id-token: write`를 준다.
+5. 외부 PR의 code를 secret 접근 권한으로 실행하게 만드는 `pull_request_target`은 사용하지 않는다.
+
+### 체크리스트
+
+- [ ] `app`·`data` BuildConfig에 필요한 값과 `build-logic`의 `getApiKey` fallback 순서를 확인한다.
+- [ ] `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`의 비밀이 아닌 placeholder가 compile·unit test·instrumentation APK build에 충분한지 로컬에서 확인한다.
+- [ ] verify job에 `contents: read` 외 권한·production secret이 없는지 workflow YAML에서 확인한다.
+- [ ] PR comment와 Pages deploy job이 verify job과 분리됐는지 확인한다.
+- [ ] fork PR, 일반 PR, `main`/`develop` push의 실행 경로와 권한을 표로 기록한다.
+- [ ] 저장소 관리자가 `Knowledge verification`과 새 verify status를 required status로 지정한다.
+
+### Exit gate
+
+- CI와 같은 Gradle command가 non-secret placeholder 환경에서 통과한다.
+- workflow YAML parse와 GitHub Actions 권한 검토를 통과한다.
+- 원격 PR에서 verify·knowledge workflow가 통과하고, production secret 로그·PR 전달이 없음을 확인한다.
+
+### 위험과 rollback
+
+이 phase는 GitHub Actions, secret, Pages 권한을 바꾸므로 Risky Change다. placeholder로 build가 되지 않으면 권한을 되돌려 secret을 재노출하지 않고, credential-free BuildConfig 설계를 별도 승인 작업으로 분리한다.
+
+## Phase 3 — Worktree와 local Android 환경 정책
+
+**목적:** Codex App worktree가 편의 때문에 local OAuth 값이나 machine-specific 설정을 복사하지 않도록 한다.
+
+### 수정 대상
+
+- `docs/ai/worktree-policy.md` (신규)
+- `docs/ai/README.md`
+- `docs/ai/registry/documents.toml`
+- `AGENTS.md`
+- 필요 시 `.worktreeinclude` (별도 보안 승인 후에만)
+
+### 적용 정책
+
+1. 기본 worktree는 secret-free·재현 가능한 read/build/test 작업만 수행한다.
+2. 현재 ignore된 `local.properties`는 SDK 경로와 OAuth 값이 함께 있을 수 있으므로 `.worktreeinclude`에 기본 등록하지 않는다.
+3. 기기 실행 또는 OAuth 수동 검증이 필요한 작업은 Local로 handoff하거나, 사용자가 worktree에 필요한 값을 직접 안전하게 준비한 뒤 진행한다.
+4. 장기적으로 local 설정을 나눌 필요가 생기면 “SDK 위치”와 “credential”을 서로 다른 ignore 파일·공급 경로로 분리하는 별도 Risky Change로 다룬다.
+
+### 체크리스트
+
+- [ ] worktree 생성, Local handoff, branch 중복 checkout 제한을 문서화한다.
+- [ ] ignore 파일을 복사하지 않는 기본값과 필요한 수동 준비 항목을 문서화한다.
+- [ ] `.worktreeinclude`를 추가하려면 대상 파일이 credential을 포함하지 않는다는 저장소 관리자 검토를 기록한다.
+- [ ] 새 worktree에서 문서·unit/compile 검증 가능 범위와 Local 전용 검증 범위를 분리한다.
+
+### Exit gate
+
+- worktree 문서가 secret 복사를 지시하지 않는다.
+- 새 worktree에서 가능한 검증과 handoff 조건이 명확하다.
+
+## Phase 4 — 공통 code review 기준과 lifecycle hook 경계
+
+**목적:** custom reviewer, `/review`, 사람이 보는 PR review가 같은 결과 기준을 사용하게 하고, Git hook과 Codex hook의 책임을 명확히 한다.
+
+### 수정 대상
+
+- `docs/ai/code-review.md` (신규)
+- `AGENTS.md`
+- `docs/ai/workflows.md`
+- `docs/ai/subagents.md`
+- `docs/ai/README.md`
+- `docs/ai/registry/documents.toml`
+
+### 적용 정책
+
+1. review는 실제 동작 회귀, 보안, 데이터 손상, navigation 계약, 테스트 누락을 우선하고, 단순 스타일 선호는 finding으로 보고하지 않는다.
+2. finding에는 심각도(`P0`~`P2`), 영향, 재현 조건 또는 근거, 파일 경로, 최소 수정 또는 검증 방법을 포함한다.
+3. `/review` 또는 custom reviewer의 범위는 base branch, 현재 diff, 특정 commit 중 하나로 명시한다.
+4. Git hook·CI가 이미 강제하는 formatter, Index, graph 검사는 Codex lifecycle hook으로 중복하지 않는다.
+5. 반복적으로 “세션 종료 전 이력·검증을 빼먹는” 실제 사례가 확인될 때만 `SessionStart` 또는 `Stop` hook을 별도 Small/Medium 작업으로 도입한다. hook은 파일 수정·stage·commit을 하지 않는다.
+
+### 체크리스트
+
+- [ ] 공통 review 문서에 심각도, evidence, false-positive 처리, test-gap 보고 형식을 추가한다.
+- [ ] `Review Workflow`가 새 문서를 참조한다.
+- [ ] agent 결과 형식과 사람/`/review` 결과 형식이 충돌하지 않는지 확인한다.
+- [ ] lifecycle hook 필요성은 실제 누락 기록을 근거로 판단하고, 필요하지 않으면 추가하지 않는다.
+
+### Exit gate
+
+- representative diff 1건에서 custom reviewer 또는 `/review` 결과가 공통 형식을 따른다.
+- 기존 Git hook·knowledge CI와 중복된 자동화가 추가되지 않는다.
+
+## Phase 5 — 운영 정착과 관리자 확인
+
+**목적:** 정책이 문서에만 남지 않도록 실제 PR과 반복 작업에서 효과를 확인한다.
+
+### 수정 대상
+
+- `docs/history/records/YYYY/`
+- 필요 시 `docs/ai/codex-operation-hardening-plan.md`의 phase 상태
+
+### 체크리스트
+
+- [ ] Phase 1~4를 각각 독립 커밋·PR로 검토한다. Phase 2는 별도 PR을 사용한다.
+- [ ] 각 phase의 exit gate, 실패 원인, rollback 여부를 history record에 남긴다.
+- [ ] 저장소 관리자가 required status와 Pages 환경 권한을 확인한다.
+- [ ] 3~5개 작업 후 subagent 사용률, 충돌, 검증 누락, review finding 품질을 회고한다.
+- [ ] 효과가 없는 규칙은 삭제가 아니라 먼저 완화 또는 범위 축소를 제안한다.
+
+### Exit gate
+
+- 최소 세 번의 Medium 이상 작업에서 policy를 적용하고, 결과가 history와 Change Report에 남아 있다.
+- CI 권한·secret 노출·worktree secret 복사·parallel write 충돌이 없음을 확인한다.
+
+## 적용 순서와 승인 경계
+
+| 순서 | Phase | 예상 크기 | 사용자/관리자 승인 |
+| --- | --- | --- | --- |
+| 1 | Phase 0 | Small | 불필요 |
+| 2 | Phase 1 | Medium | reviewer hard read-only 정책 승인 |
+| 3 | Phase 2 | Large / Risky | GitHub Actions·secret·Pages 권한 및 required status 승인 |
+| 4 | Phase 3 | Medium | `.worktreeinclude` 추가 시 보안 승인 |
+| 5 | Phase 4 | Medium | lifecycle hook 추가 시 승인 |
+| 6 | Phase 5 | 운영 확인 | repository 관리자 설정 확인 |
+
+## 금지 사항
+
+- production OAuth credential, `local.properties`, keystore, token을 문서·worktree·agent output·CI log에 복사하거나 출력하지 않는다.
+- branch protection, required status, GitHub secret, Pages 설정을 API나 CLI로 자동 변경하지 않는다.
+- `pull_request_target`로 PR build secret 문제를 우회하지 않는다.
+- reviewer agent를 병렬 write worker로 사용하지 않는다.
+- Phase 2 이전에 build workflow의 권한·secret을 단독으로 바꾸지 않는다.
+
+## 공통 검증
+
+모든 문서/agent 정책 phase는 다음을 실행한다. Android/CI 변경 phase는 해당 phase가 정한 Gradle·원격 CI 검증을 추가한다.
+
+```bash
+python3 scripts/ai/generate_knowledge_index.py --check
+python3 scripts/ai/verify_knowledge_graph.py
+python3 -m unittest discover -s scripts/ai/tests -p 'test_*.py'
+git diff --check
+git status --short
+```

--- a/docs/ai/codex-operation-hardening-plan.md
+++ b/docs/ai/codex-operation-hardening-plan.md
@@ -158,7 +158,7 @@ Uncertainty: <none or missing evidence>
 1. compile·lint·test job은 `permissions: { contents: read }`만 가진다.
 2. PR build에는 production `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`, cache encryption secret을 주입하지 않는다. 현재 `getApiKey`가 이 값을 요구하므로 먼저 비밀이 아닌 고정 CI placeholder로 전체 Gradle 검증이 되는지 확인한다.
 3. JaCoCo PR 댓글을 유지한다면 별도 job으로 분리해 `pull-requests: write`만 준다. fork PR에서는 댓글 job을 실행하지 않는다.
-4. Pages upload·deploy는 `main`·`develop` push 전용 별도 job으로 분리해 그 job에만 `pages: write`, `id-token: write`를 준다.
+4. Pages upload·deploy는 `develop` push 전용 별도 job으로 분리해 그 job에만 `pages: write`, `id-token: write`를 준다. `main` push는 build만 실행해 하나의 GitHub Pages 사이트를 덮어쓰지 않는다.
 5. 외부 PR의 code를 secret 접근 권한으로 실행하게 만드는 `pull_request_target`은 사용하지 않는다.
 
 ### 체크리스트
@@ -167,7 +167,7 @@ Uncertainty: <none or missing evidence>
 - [x] `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`의 비밀이 아닌 placeholder가 compile·unit test·instrumentation APK build에 충분한지 로컬에서 확인한다.
 - [x] verify job에 `contents: read` 외 권한·production secret이 없는지 workflow YAML에서 확인한다.
 - [x] PR comment와 Pages deploy job이 verify job과 분리됐는지 확인한다.
-- [x] fork PR, 일반 PR, `main`/`develop` push의 실행 경로와 권한을 표로 기록한다.
+- [x] fork PR, 일반 PR, `main`/`develop` build와 `develop` Pages 배포의 실행 경로·권한을 표로 기록한다.
 - [ ] 저장소 관리자가 `Knowledge verification`과 새 verify status를 required status로 지정한다.
 
 ### Exit gate
@@ -180,7 +180,7 @@ Uncertainty: <none or missing evidence>
 
 - `build` job은 `contents: read`만 사용하며, `CLIENT_ID`·`CLIENT_SECRET`·`REDIRECT_URI`에 비밀이 아닌 고정 placeholder를 전달한다. Gradle cache encryption secret과 OAuth secret 검증 step은 제거했다.
 - `coverage-comment` job은 internal PR에서만 실행하고 `pull-requests: write`만 사용한다. fork PR은 job 조건에서 제외한다.
-- `deploy-pages` job은 `main`·`develop` push에서만 실행하고 `pages: write`, `id-token: write`만 사용한다. Gradle 산출물은 일반 artifact로 전달되며 deploy job은 source checkout이나 Gradle 실행을 하지 않는다.
+- `deploy-pages` job은 `develop` push에서만 실행하고 `pages: write`, `id-token: write`만 사용한다. `main` push는 build만 실행한다. Gradle 산출물은 일반 artifact로 전달되며 deploy job은 source checkout이나 Gradle 실행을 하지 않는다.
 - 로컬 placeholder 검증과 YAML 검토는 완료했다. required status 지정과 원격 PR 실행 확인은 저장소 관리자·후속 PR 단계에서 완료한다.
 
 ### 위험과 rollback
@@ -288,10 +288,9 @@ Uncertainty: <none or missing evidence>
 
 ### Phase 5 현재 상태
 
-- Phase 0~4는 독립 commit과 completed history record를 갖는다. Phase 2의 draft PR #161은 Build·Knowledge·coverage comment 성공과 Pages deploy skip을 확인했다.
-- PR #161의 remote head는 아직 `b6bba07`이며, Phase 3·4 commit은 local branch에만 있다. push 후 PR CI를 다시 확인해야 한다.
-- `develop`은 현재 branch protection이 없어 required status가 지정되지 않았다. 이는 저장소 관리자만 변경한다.
-- `github-pages` environment에는 branch policy가 있으나 protected branch 전용은 아니다. Pages 권한·배포 branch 정책은 관리자 확인이 필요하다.
+- Phase 0~4는 독립 commit과 completed history record를 갖는다. draft PR #161은 최신 remote head `3bc4acd`에서 Build·Knowledge·coverage comment 성공과 Pages deploy skip을 확인했다.
+- 저장소 관리자가 `develop` branch ruleset을 만들고 PR·`Build & Coverage`·`Generated index and graph`를 병합 조건으로 지정했다. 원격 설정의 최종 read-only 재확인은 다음 PR CI 확인과 함께 남아 있다.
+- `github-pages` environment는 `develop`만 배포하도록 유지한다. `main`과 `develop`이 하나의 Pages 사이트를 번갈아 덮어쓰지 않도록 workflow의 artifact·deploy 조건도 `develop` push 전용으로 조정한다.
 - 실제 Codex managed worktree의 Android 검증·Local handoff 반복 사례와 review 품질 3~5건 회고는 아직 부족하다.
 
 ## 적용 순서와 승인 경계

--- a/docs/ai/codex-operation-hardening-plan.md
+++ b/docs/ai/codex-operation-hardening-plan.md
@@ -1,6 +1,6 @@
 # Codex 운영 정책 보강 명세
 
-> **Status:** active — Phase 0 completed, Phase 1 pending
+> **Status:** active — Phase 0 and Phase 1 completed, Phase 2 pending
 >
 > **Purpose:** GithubSearch의 Codex 운영 정책을 공식 Codex 가이드의 durable guidance, bounded subagent, 최소 권한, worktree 안전성 원칙에 맞춰 단계적으로 보강한다.
 >
@@ -13,8 +13,8 @@
 | 책임 영역 | 정본·담당 | 현재 상태 | 다음 변경 phase |
 | --- | --- | --- | --- |
 | 작업 범위·최종 판단·보고 | main agent, `AGENTS.md`, `knowledge-operations.md` | 운영 중 | 유지 |
-| reviewer 역할·근거·write 권한 | `.codex/agents/*.toml`, `subagents.md` | 정책상 review-first | Phase 1에서 hard read-only로 강제 |
-| Codex session 기본값 | 사용자 전역 config, project `.codex/config.toml` | project config 없음 | Phase 1에서 project 불변값만 추가 |
+| reviewer 역할·근거·write 권한 | `.codex/agents/*.toml`, `subagents.md` | hard read-only 설정과 runtime 결과 형식 확인 완료 | 유지 |
+| Codex session 기본값 | 사용자 전역 config, project `.codex/config.toml` | reviewer 최대 병렬 수 3 적용 | 유지 |
 | staged 변경 검사 | `.githooks/pre-commit` | 운영 중, clone/worktree별 설치 필요 | 유지 |
 | 문서·agent 지식 관계 | registry, generated Index, `knowledge.yml` | 운영 중, read-only CI | 유지 |
 | Android build·coverage·배포 권한 | `build.yml`, 저장소 관리자 | 한 job에 혼재 | Phase 2에서 verify/comment/deploy 분리 |
@@ -23,7 +23,7 @@
 
 이 분리는 다음 경계를 고정한다.
 
-- main agent와 reviewer의 책임은 즉시 분리한다. Phase 1 전까지 reviewer의 현재 제한된 write 예외는 유지되지만, main agent가 write scope·최종 적용·검증을 계속 소유한다.
+- main agent와 reviewer의 책임은 분리한다. reviewer는 hard read-only이며, main agent가 구현·write scope·최종 적용·검증을 계속 소유한다.
 - project repository는 팀 공통 불변값만 보관한다. 모델·reasoning·개인 connector·승인 설정은 사용자 전역 config에 남긴다.
 - Git hook은 commit 시점, `knowledge.yml`은 PR 시점, 향후 Codex lifecycle hook은 세션 시점을 담당한다. 동일 검사를 여러 계층에 복제하지 않는다.
 - CI 권한, OAuth secret, Pages 배포, branch protection은 repository 관리자와 명시적 Risky Change 승인 없이는 변경하지 않는다.
@@ -121,18 +121,25 @@ Uncertainty: <none or missing evidence>
 
 ### 체크리스트
 
-- [ ] 모든 reviewer TOML의 name, description, scope, required documents가 registry와 일치한다.
-- [ ] 모든 reviewer가 read-only sandbox, Git 금지, secret 금지, 위험 변경 보고, 근거 경로 반환을 가진다.
-- [ ] `subagents.md`에 Small 변경은 single agent, 독립 read-only 검토는 최대 3개 병렬, write는 1명이라는 dispatcher 표를 추가한다.
-- [ ] `AGENTS.md`에 “명시적 요청 또는 project workflow가 정한 경우에만 subagent 위임” 원칙을 추가한다.
-- [ ] reviewer가 답변만 하고 파일을 수정하지 않는 수동 확인을 한 번 기록한다.
+- [x] 모든 reviewer TOML의 name, description, scope, required documents가 registry와 일치한다.
+- [x] 모든 reviewer가 read-only sandbox, Git 금지, secret 금지, 위험 변경 보고, 근거 경로 반환을 가진다.
+- [x] `subagents.md`에 Small 변경은 single agent, 독립 read-only 검토는 최대 3개 병렬, write는 1명이라는 dispatcher 표를 추가한다.
+- [x] `AGENTS.md`에 “명시적 요청 또는 project workflow가 정한 경우에만 subagent 위임” 원칙을 추가한다.
+- [x] `compose-ui-reviewer`를 명시 호출해 파일 수정 없이 common output format과 근거 경로를 반환하는 runtime 수동 확인을 기록했다.
 
 ### Exit gate
 
 - `python3 scripts/ai/generate_knowledge_index.py --check`
 - `python3 scripts/ai/verify_knowledge_graph.py`
 - agent TOML 경로·ID·required document 관계 검사 통과
-- main agent가 reviewer 결과를 합쳐 최종 판단·검증·보고를 작성한 예시 1건 확인
+- 새 Codex session 또는 명시적 reviewer 호출에서 reviewer가 파일 수정 없이 결과 형식을 반환하고, main agent가 이를 최종 판단·검증·보고에 통합한 예시 1건 확인
+
+### Phase 1 실행 결과
+
+- 다섯 reviewer TOML에 `sandbox_mode = "read-only"`를 설정하고, 제한된 write 위임 예외를 제거했다.
+- project `.codex/config.toml`에 reviewer 최대 병렬 수 3을 설정했다. 모델·reasoning·connector·승인 설정은 repository에 고정하지 않았다.
+- `AGENTS.md`와 `subagents.md`에 명시적 위임, Small 변경의 single-agent 기본값, 독립 read-only 검토 최대 3개, write 담당 1명, 공통 결과 형식을 추가했다.
+- `compose-ui-reviewer`를 명시 호출해 문서·코드 근거와 finding을 반환하고, working tree에 reviewer의 파일 변경이 없음을 확인했다. Phase 1 운영 exit gate를 완료했다.
 
 ## Phase 2 — Build CI 최소 권한과 secret 없는 검증
 

--- a/docs/ai/codex-operation-hardening-plan.md
+++ b/docs/ai/codex-operation-hardening-plan.md
@@ -1,6 +1,6 @@
 # Codex 운영 정책 보강 명세
 
-> **Status:** active — Phase 0~3 completed, Phase 4~5 planned
+> **Status:** active — Phase 0~4 completed, Phase 5 planned
 >
 > **Purpose:** GithubSearch의 Codex 운영 정책을 공식 Codex 가이드의 durable guidance, bounded subagent, 최소 권한, worktree 안전성 원칙에 맞춰 단계적으로 보강한다.
 >
@@ -50,9 +50,9 @@
 | durable guidance | `AGENTS.md`와 `docs/ai/*`가 역할·검증·위험 변경을 정의 | 6.3KB의 간결한 root 지시와 주제별 분리 | 실제 권한 강제와 reviewer 결과 형식 |
 | custom agent | 5개 reviewer와 registry·근거 경로 반환 규칙 존재 | review-first, Git·secret 금지, parent 책임 | technical read-only, 병렬 위임 판단 기준 |
 | Git hook·knowledge CI | staged guard와 `contents: read` knowledge CI 존재 | 생성 Index·graph 관계 검사 | 새 clone/worktree 설치 안내와 Codex lifecycle hook의 경계 |
-| build CI | build·coverage·PR comment·Pages 배포가 하나의 job에 있음 | build/knowledge workflow 분리 | job별 최소 권한과 production OAuth secret 제거 |
-| worktree | Git worktree 사용 가능 | Git branch 충돌 방지 | ignore된 `local.properties`의 안전한 처리 정책 |
-| review | 역할별 reviewer는 존재 | 파일·근거 중심 검토 | 공통 심각도와 `/review` 결과 기준 |
+| build CI | verify·PR comment·Pages deploy가 분리되고 PR 원격 검증 완료 | build/knowledge workflow 분리 | required status 관리자 지정 |
+| worktree | `worktree-policy.md`로 secret-free·Local handoff 경계 적용 | Git branch 충돌 방지 | Phase 5 실제 worktree 사례 회고 |
+| review | `code-review.md`, reviewer, `/review`, 사람 PR review | P0~P2·scope·근거·test-gap 공통 기준 적용 | Phase 5에서 실제 review 품질 회고 |
 
 ## Phase 0 — 결정 고정과 기준선 검사
 
@@ -112,9 +112,10 @@
 
 ```text
 Verdict: <pass / finding / insufficient context>
+Review scope: <base branch / commit / working-tree diff / requested files>
 Primary-document evidence: <path>
 Code/test evidence: <path>
-Findings: <severity, impact, affected path>
+Findings: <P0/P1/P2, impact, affected path>
 Verification or follow-up: <minimum action>
 Uncertainty: <none or missing evidence>
 ```
@@ -246,15 +247,22 @@ Uncertainty: <none or missing evidence>
 
 ### 체크리스트
 
-- [ ] 공통 review 문서에 심각도, evidence, false-positive 처리, test-gap 보고 형식을 추가한다.
-- [ ] `Review Workflow`가 새 문서를 참조한다.
-- [ ] agent 결과 형식과 사람/`/review` 결과 형식이 충돌하지 않는지 확인한다.
-- [ ] lifecycle hook 필요성은 실제 누락 기록을 근거로 판단하고, 필요하지 않으면 추가하지 않는다.
+- [x] 공통 review 문서에 심각도, evidence, false-positive 처리, test-gap 보고 형식을 추가한다.
+- [x] `Review Workflow`가 새 문서를 참조한다.
+- [x] agent 결과 형식과 사람/`/review` 결과 형식이 충돌하지 않는지 확인한다.
+- [x] lifecycle hook 필요성은 실제 누락 기록을 근거로 판단하고, 필요하지 않으면 추가하지 않는다.
 
 ### Exit gate
 
 - representative diff 1건에서 custom reviewer 또는 `/review` 결과가 공통 형식을 따른다.
 - 기존 Git hook·knowledge CI와 중복된 자동화가 추가되지 않는다.
+
+### Phase 4 실행 결과
+
+- `code-review.md`에 review scope, P0~P2 severity, evidence·false-positive·test-gap, 공통 결과 형식, Git hook·CI·lifecycle hook 책임을 정의했다.
+- `AGENTS.md`, Review Workflow, subagent 문서와 다섯 reviewer TOML에 review scope와 P0~P2 형식을 연결했다.
+- `compose-ui-reviewer`가 Liquid navigation 후보를 read-only로 검토해 scope·문서/코드 근거·P2 finding·follow-up·uncertainty 형식을 반환하는 것을 확인했다.
+- 기존 Git hook·Knowledge CI가 기계적 검증을 담당하고, 현재 작업 이력에서 반복된 세션 종료 누락 근거가 없으므로 lifecycle hook은 추가하지 않았다.
 
 ## Phase 5 — 운영 정착과 관리자 확인
 

--- a/docs/ai/codex-operation-hardening-plan.md
+++ b/docs/ai/codex-operation-hardening-plan.md
@@ -162,11 +162,11 @@ Uncertainty: <none or missing evidence>
 
 ### 체크리스트
 
-- [ ] `app`·`data` BuildConfig에 필요한 값과 `build-logic`의 `getApiKey` fallback 순서를 확인한다.
-- [ ] `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`의 비밀이 아닌 placeholder가 compile·unit test·instrumentation APK build에 충분한지 로컬에서 확인한다.
-- [ ] verify job에 `contents: read` 외 권한·production secret이 없는지 workflow YAML에서 확인한다.
-- [ ] PR comment와 Pages deploy job이 verify job과 분리됐는지 확인한다.
-- [ ] fork PR, 일반 PR, `main`/`develop` push의 실행 경로와 권한을 표로 기록한다.
+- [x] `app`·`data` BuildConfig에 필요한 값과 `build-logic`의 `getApiKey` fallback 순서를 확인한다.
+- [x] `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`의 비밀이 아닌 placeholder가 compile·unit test·instrumentation APK build에 충분한지 로컬에서 확인한다.
+- [x] verify job에 `contents: read` 외 권한·production secret이 없는지 workflow YAML에서 확인한다.
+- [x] PR comment와 Pages deploy job이 verify job과 분리됐는지 확인한다.
+- [x] fork PR, 일반 PR, `main`/`develop` push의 실행 경로와 권한을 표로 기록한다.
 - [ ] 저장소 관리자가 `Knowledge verification`과 새 verify status를 required status로 지정한다.
 
 ### Exit gate
@@ -174,6 +174,13 @@ Uncertainty: <none or missing evidence>
 - CI와 같은 Gradle command가 non-secret placeholder 환경에서 통과한다.
 - workflow YAML parse와 GitHub Actions 권한 검토를 통과한다.
 - 원격 PR에서 verify·knowledge workflow가 통과하고, production secret 로그·PR 전달이 없음을 확인한다.
+
+### Phase 2 실행 결과
+
+- `build` job은 `contents: read`만 사용하며, `CLIENT_ID`·`CLIENT_SECRET`·`REDIRECT_URI`에 비밀이 아닌 고정 placeholder를 전달한다. Gradle cache encryption secret과 OAuth secret 검증 step은 제거했다.
+- `coverage-comment` job은 internal PR에서만 실행하고 `pull-requests: write`만 사용한다. fork PR은 job 조건에서 제외한다.
+- `deploy-pages` job은 `main`·`develop` push에서만 실행하고 `pages: write`, `id-token: write`만 사용한다. Gradle 산출물은 일반 artifact로 전달되며 deploy job은 source checkout이나 Gradle 실행을 하지 않는다.
+- 로컬 placeholder 검증과 YAML 검토는 완료했다. required status 지정과 원격 PR 실행 확인은 저장소 관리자·후속 PR 단계에서 완료한다.
 
 ### 위험과 rollback
 

--- a/docs/ai/cross-project-operation-principles-template.md
+++ b/docs/ai/cross-project-operation-principles-template.md
@@ -1,0 +1,100 @@
+# Cross-Project Codex 운영 원칙 템플릿
+
+> **Status:** provisional — GithubSearch의 Phase 0~2 실행 결과를 바탕으로 만든 초안이다. Phase 3~5의 실제 운영 결과를 반영해 확정·분리·축소한다.
+>
+> **Purpose:** Android/Kotlin 프로젝트를 포함한 다른 repository에 Codex 운영 체계를 도입할 때, 그대로 복사할 규칙과 프로젝트별로 다시 판단할 설정을 구분한다.
+
+## 사용 방법
+
+이 문서는 다른 repository의 `AGENTS.md`, `docs/ai/`, CI workflow를 만들기 전의 설계 기준이다. project-specific 값, action, branch 이름, Gradle task를 그대로 복사하지 않는다.
+
+1. 현재 repository의 코드·CI·secret 입력·worktree 동작을 먼저 조사한다.
+2. 아래 공통 원칙 중 적용할 항목을 고르고, project-specific 매핑 표를 작성한다.
+3. 권한, secret, 배포, branch protection 변경은 별도 승인과 원격 CI 검증을 거친다.
+4. 도입 결과와 예외는 작업 이력에 남긴다.
+
+## 공통 원칙
+
+### 1. 문서와 자동 강제의 책임을 분리한다
+
+- `AGENTS.md`와 문서는 사람이 판단할 기준, 역할, 예외를 설명한다.
+- CI, Git hook, agent sandbox는 기계적으로 확인 가능한 최소 규칙만 강제한다.
+- 같은 formatter, 문서 관계 검사, test를 여러 계층에서 중복 실행하지 않는다.
+
+### 2. 권한은 실행 단위별로 최소화한다
+
+- build·lint·test job은 source를 읽는 데 필요한 권한만 가진다.
+- PR 댓글, release, deployment, repository write는 별도 job으로 분리하고 필요한 권한만 부여한다.
+- build output은 artifact로 전달하고, 쓰기 권한 job이 PR source를 checkout하거나 임의 build command를 실행하지 않도록 설계한다.
+
+### 3. PR 검증 입력으로 production secret을 사용하지 않는다
+
+- compile·test에 값의 존재만 필요하다면 non-secret placeholder 또는 test fixture를 사용한다.
+- 실제 credential이 필요한 통합 검증은 신뢰된 환경, protected branch, 또는 사용자가 안전하게 준비한 Local 환경으로 분리한다.
+- `pull_request_target`로 PR source에 secret 접근 권한을 주어 이 문제를 우회하지 않는다.
+- secret은 문서, agent 결과, build log, artifact, worktree 복사 대상에 기록하지 않는다.
+
+### 4. 검토와 수정을 분리한다
+
+- reviewer는 기본 read-only로 두고, 근거·영향·최소 후속 조치만 반환한다.
+- 실제 수정은 main agent 또는 명시적인 write scope를 받은 담당자가 수행한다.
+- 독립적인 read-heavy 조사만 제한적으로 병렬화하고, 같은 동작이나 파일을 바꾸는 작업은 write 담당자 한 명이 소유한다.
+
+### 5. worktree는 재현 가능한 범위로 제한한다
+
+- ignore된 `local.properties`, keystore, token, 개인 SDK 설정은 기본적으로 worktree에 복사하지 않는다.
+- secret 없이 가능한 문서·compile·unit test와 Local 전용 기기·OAuth 검증을 구분한다.
+- local 설정을 공유해야 한다면 SDK 위치와 credential을 분리할 수 있는지 먼저 검토한다.
+
+### 6. 보고와 작업 이력을 결과 중심으로 남긴다
+
+- Medium 이상 작업과 policy·agent·CI 변경은 요청, 근거, 결정, 변경, 검증, 남은 위험을 기록한다.
+- 최종 보고는 수정 사항, 실행한 검증, 실행하지 못한 검증, 다음 승인 또는 운영 항목을 구분한다.
+- 원문 대화, 내부 추론, secret, token, 개인 정보는 이력에 기록하지 않는다.
+
+### 7. 단계적으로 도입하고 원격에서 확인한다
+
+- policy 확정, agent 권한, CI 권한, worktree, review 기준, 운영 정착을 작은 phase로 나눈다.
+- 각 phase는 local 검증과 원격 CI 확인을 분리하고, 실패 시 secret 재노출 대신 설계를 조정한다.
+- branch protection, required status, deployment environment는 저장소 관리자가 원격 실행을 확인한 후 적용한다.
+
+## 프로젝트별 조정 표
+
+| 영역 | 반드시 조사할 항목 | 예시 결정 |
+| --- | --- | --- |
+| Build 입력 | 빌드가 요구하는 값, 실제 네트워크 호출 여부 | placeholder 가능 여부, test fixture 분리 |
+| CI 검증 | 모듈 구조, Gradle task, 테스트 종류 | 최소 local command와 CI full command |
+| GitHub 권한 | checkout, PR comment, release, Pages·배포 여부 | job별 `permissions`와 실행 조건 |
+| Secret | credential 종류, 전달 경로, artifact/log 노출 | PR 미전달, trusted 환경 분리 |
+| Branch | default/protected branch와 release branch | PR base, deploy push branch |
+| Agent | 읽기 검토 역할, write 담당, 병렬 가능 범위 | reviewer sandbox와 동시성 제한 |
+| Worktree | ignore 파일, SDK, device, signing 요구 | Local handoff 조건 |
+| 보고 | 문서 registry, history, Change Report 형식 | 필수 검증·위험 기록 방식 |
+
+## 도입 전 체크리스트
+
+- [ ] 이 repository에서 실제 secret이 필요한 검증과 placeholder로 가능한 검증을 구분했다.
+- [ ] PR source가 실행되는 job의 권한과 secret 입력을 확인했다.
+- [ ] comment·deploy·release 권한을 build job과 분리할 수 있는지 확인했다.
+- [ ] worktree가 복사하지 말아야 할 ignore 파일과 Local 전용 검증을 확인했다.
+- [ ] project-specific Gradle task, branch, action, artifact 이름을 새로 정했다.
+- [ ] 저장소 관리자 승인과 원격 CI 확인이 필요한 변경을 분리했다.
+
+## GithubSearch에서 검증할 후속 보완
+
+이 초안은 Phase 3~5 완료 후 아래를 재검토한다.
+
+- worktree 정책이 실제 신규 worktree와 Local handoff에서 충분한지
+- 공통 review 형식이 custom reviewer와 사람 review에서 모두 유효한지
+- Phase 2 artifact 전달과 최소 권한 job이 원격 PR·push에서 안정적으로 동작하는지
+- 반복 작업에서 이력·검증·subagent 정책이 과도한지 또는 부족한지
+- 독립 문서, skill, bootstrap template 중 어디에 어떤 수준으로 승격할지
+
+## 이 템플릿에 포함하지 않는 것
+
+- 특정 OAuth provider의 key 이름이나 credential 값
+- 특정 GitHub Action의 버전·PR comment 형식·coverage 도구
+- 특정 Android 모듈 구조·Gradle task·SDK 버전
+- 개인 모델, reasoning, connector, 승인 설정
+
+이 값들은 해당 repository의 코드와 운영 환경을 조사한 뒤 project-specific 문서에 기록한다.

--- a/docs/ai/navigation-contracts.md
+++ b/docs/ai/navigation-contracts.md
@@ -1,0 +1,48 @@
+# Navigation Contracts
+
+## 목적과 적용 범위
+
+이 문서는 현재 `GithubSearch` 구현에 존재하는 Compose navigation 계약을 기록하는 정본이다. route, argument, 호출자와 목적지 호환성, back stack, 상태 복원, 하단 navigation 표시 규칙을 변경하기 전에 이 문서와 현재 코드를 함께 확인한다.
+
+이 문서는 type-safe navigation 전환을 지시하지 않는다. 해당 전환은 아직 계획 상태인 `docs/plan/TYPE_SAFE_NAVIGATION_MIGRATION_PLAN.md`의 별도 위험 변경이다.
+
+## 현재 route와 argument 계약
+
+| 대상 | route 계약 | argument | 현재 호출자 |
+| --- | --- | --- | --- |
+| Home | `HOME` | 없음 | `NavHost`의 start destination, 하단 navigation |
+| Favorite | `FAVORITE` | 없음 | 하단 navigation |
+| Setting | `SETTING` | 없음 | 하단 navigation |
+| Detail | `DETAIL/{id}?from={from}` | `id`: 필수 String, `from`: 필수 String이며 기본값은 빈 문자열 | Home 일반 목록, Home 검색 결과, Favorite |
+
+- route 문자열은 `app/src/main/java/com/gyleedev/githubsearch/ui/Const.kt`에 선언되고 `BottomNavItem`이 이를 화면 route로 노출한다.
+- `DetailViewModel`은 `SavedStateHandle`의 `id`를 읽어 사용자·repository 로딩을 시작한다. 따라서 Detail 호출자는 비어 있지 않은 `id`를 전달해야 한다.
+- `from`은 `DetailScreen`에 그대로 전달되는 출발 화면 구분 값이다. 현재 값은 Home 일반 목록의 `home`, Home 검색 결과의 `search`, Favorite의 `favorite`이며, argument가 없는 호환 호출에는 기본값 `""`이 사용된다.
+
+## 호출·back stack·상태 계약
+
+- Detail의 세 호출자는 모두 `GithubSearchScreen`에 있으며, 목적지 route 형식과 `from` 값을 함께 결정한다. 호출자 또는 값 변경은 Detail 화면의 화면 전환·표시 동작을 함께 확인해야 한다.
+- Detail의 뒤로 가기는 `navController.navigateUp()`을 사용한다. 이 동작은 현재 back stack에 의존하므로 route를 직접 진입시키거나 호출 구조를 바꿀 때 별도 검증이 필요하다.
+- 하단 navigation은 Home·Favorite·Setting만 노출한다. 현재 destination route가 `DETAIL`로 시작하면 하단 바를 숨긴다.
+- 하단 navigation 전환은 start destination까지 `popUpTo`하면서 `saveState = true`를 사용하고, `launchSingleTop = true`, `restoreState = true`를 사용한다. 따라서 탭 route나 start destination을 바꾸면 중복 destination과 탭별 상태 복원을 함께 검증해야 한다.
+- Detail의 `id`는 `SavedStateHandle`로 복원된다. 반면 `from`은 현재 `DetailScreen`의 navigation argument에서 직접 읽으므로 두 argument의 전달·복원 경로를 분리해 확인한다.
+
+## Deep link와 테스트 현황
+
+- 현재 `app`과 `feature`의 navigation 선언에는 `deepLink` 또는 `deepLinks` 사용이 없다. deep link 도입·변경은 새 외부 진입 계약이므로 위험 변경으로 다룬다.
+- 현재 unit test는 `feature/detail/src/test/java/com/gyleedev/githubsearch/feature/detail/DetailViewModelTest.kt`에서 `SavedStateHandle`의 `id` 전달 여부를 확인한다. route 조립, `from` 값, `navigateUp()`, 하단 navigation의 상태 복원을 직접 검증하는 navigation test는 현재 검색 범위에서 찾지 못했다.
+
+## 위험 변경과 최소 검증
+
+다음 변경은 `docs/ai/task-scope-control.md`의 위험 변경 절차를 먼저 적용한다.
+
+- route 제거·이름 변경, Detail argument의 이름·필수성·기본값 변경
+- `from` 값 또는 해석 변경, 호출자와 목적지의 호환성 제거
+- deep link 추가·변경, back stack·탭 상태 복원 규칙 변경
+- navigation 관련 public API, module dependency, Gradle dependency, DI 변경
+
+최소 확인은 변경된 각 호출자에서 Detail route와 argument를 확인하고, 목적지에서 argument 수신과 뒤로 가기 동작을 확인하는 것이다. 탭 navigation을 건드리면 중복 화면 방지와 상태 복원까지 확인한다. 코드 변경이면 `docs/ai/quality-gates.md`에 따라 가장 좁은 관련 Gradle 검증을 선택하고, navigation behavior test의 필요성은 `test-strategy-reviewer`와 함께 판단한다.
+
+## 검토 역할 사용 규칙
+
+`navigation-contract-reviewer`는 review-first 역할이다. 결론 전 이 문서 같은 관련 정본 문서와 현재 영향 코드 또는 테스트를 읽고, 결과에 두 근거 경로를 모두 남긴다. 파일 수정은 주 작업자가 명시한 제한된 write 범위에서만 가능하며, 최종 적용·위험 판단·검증·보고 책임은 주 작업자에게 남는다.

--- a/docs/ai/quality-gates.md
+++ b/docs/ai/quality-gates.md
@@ -64,7 +64,8 @@ CI full command는 CI 기준의 full verification이며 local에서 항상 강�
 | --- | --- | --- | --- |
 | 일반 PR | `build`, `coverage-comment` | `contents: read`, `pull-requests: write` | build는 non-secret placeholder만 사용하고, 댓글 job은 JaCoCo artifact만 받아 PR 댓글만 작성한다. |
 | fork PR | `build` | `contents: read` | 댓글 job을 실행하지 않는다. production OAuth·Gradle cache encryption secret을 전달하지 않는다. |
-| `main`/`develop` push | `build`, `deploy-pages` | `contents: read`, `pages: write`·`id-token: write` | deploy job은 build가 전달한 Pages package만 업로드·배포하며 source checkout·Gradle 실행을 하지 않는다. |
+| `main` push | `build` | `contents: read` | build·coverage 검증만 실행하며 GitHub Pages를 덮어쓰지 않는다. |
+| `develop` push | `build`, `deploy-pages` | `contents: read`, `pages: write`·`id-token: write` | deploy job은 build가 전달한 Pages package만 업로드·배포하며 source checkout·Gradle 실행을 하지 않는다. |
 
 - `pull_request_target`은 사용하지 않는다.
 - `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`는 build job에서 `githubsearch-ci-placeholder`, `githubsearch://ci` 같은 비밀이 아닌 고정 값으로만 제공한다.

--- a/docs/ai/quality-gates.md
+++ b/docs/ai/quality-gates.md
@@ -56,6 +56,21 @@ hook은 Gradle이 working tree를 읽기 때문에 values 리소스를 수정한
 
 CI full command는 CI 기준의 full verification이며 local에서 항상 강제하지 않는다. local에서는 변경 범위에 맞는 최소 검증을 우선하고, 여러 모듈, DI, Gradle, build-logic 영향처럼 범위가 넓은 경우 CI full command 실행을 고려한다.
 
+### Build CI 권한과 실행 경로
+
+`build.yml`은 PR 코드가 production credential 또는 Pages 배포 권한으로 실행되지 않도록 job을 분리한다. build job의 CI 입력값은 컴파일용 고정 placeholder이며 OAuth 운영값이 아니다.
+
+| 이벤트 | 실행 job | 권한 | secret/배포 경계 |
+| --- | --- | --- | --- |
+| 일반 PR | `build`, `coverage-comment` | `contents: read`, `pull-requests: write` | build는 non-secret placeholder만 사용하고, 댓글 job은 JaCoCo artifact만 받아 PR 댓글만 작성한다. |
+| fork PR | `build` | `contents: read` | 댓글 job을 실행하지 않는다. production OAuth·Gradle cache encryption secret을 전달하지 않는다. |
+| `main`/`develop` push | `build`, `deploy-pages` | `contents: read`, `pages: write`·`id-token: write` | deploy job은 build가 전달한 Pages package만 업로드·배포하며 source checkout·Gradle 실행을 하지 않는다. |
+
+- `pull_request_target`은 사용하지 않는다.
+- `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`는 build job에서 `githubsearch-ci-placeholder`, `githubsearch://ci` 같은 비밀이 아닌 고정 값으로만 제공한다.
+- `GRADLE_CACHE_ENCRYPTION_KEY`를 CI job에 전달하지 않는다.
+- 저장소 관리자는 원격 PR에서 새 job이 정상 동작함을 확인한 뒤, 필요한 verify status와 `Knowledge verification`을 required status로 지정한다.
+
 ## Verification Section
 
 최종 응답의 Verification 섹션에는 아래 내용을 포함한다.

--- a/docs/ai/registry/agents.toml
+++ b/docs/ai/registry/agents.toml
@@ -3,19 +3,29 @@ schema_version = 1
 [[agent]]
 id = "compose-ui-reviewer"
 path = ".codex/agents/compose-ui-reviewer.toml"
-required_documents = ["root-agents", "ui-guidelines", "coding-conventions", "quality-gates"]
+scope = "Compose UI와 design system 검토"
+required_documents = ["knowledge-operations", "root-agents", "ui-guidelines", "coding-conventions", "quality-gates"]
 
 [[agent]]
 id = "data-domain-boundary-guard"
 path = ".codex/agents/data-domain-boundary-guard.toml"
-required_documents = ["root-agents", "data-logic", "coding-conventions", "task-scope", "testing-guide"]
+scope = "data/domain 경계와 Room·DI 영향 검토"
+required_documents = ["knowledge-operations", "root-agents", "data-logic", "coding-conventions", "task-scope", "testing-guide"]
+
+[[agent]]
+id = "navigation-contract-reviewer"
+path = ".codex/agents/navigation-contract-reviewer.toml"
+scope = "route·argument·deep link·back stack 계약 검토"
+required_documents = ["knowledge-operations", "navigation-contracts", "task-scope", "quality-gates", "ui-guidelines"]
 
 [[agent]]
 id = "state-flow-architect"
 path = ".codex/agents/state-flow-architect.toml"
-required_documents = ["root-agents", "data-logic", "coding-conventions", "quality-gates", "task-scope"]
+scope = "ViewModel·StateFlow·UiState 검토"
+required_documents = ["knowledge-operations", "root-agents", "data-logic", "coding-conventions", "quality-gates", "task-scope"]
 
 [[agent]]
 id = "test-strategy-reviewer"
 path = ".codex/agents/test-strategy-reviewer.toml"
-required_documents = ["root-agents", "quality-gates", "testing-guide", "data-logic"]
+scope = "행동 중심 테스트 전략 검토"
+required_documents = ["knowledge-operations", "root-agents", "quality-gates", "testing-guide", "data-logic"]

--- a/docs/ai/registry/documents.toml
+++ b/docs/ai/registry/documents.toml
@@ -127,6 +127,13 @@ authority = "primary"
 code_paths = [".codex/agents", "docs/ai"]
 
 [[document]]
+id = "navigation-contracts"
+path = "docs/ai/navigation-contracts.md"
+kind = "architecture"
+authority = "primary"
+code_paths = ["app", "feature/detail"]
+
+[[document]]
 id = "task-scope"
 path = "docs/ai/task-scope-control.md"
 kind = "policy"

--- a/docs/ai/registry/documents.toml
+++ b/docs/ai/registry/documents.toml
@@ -120,6 +120,13 @@ authority = "primary"
 code_paths = ["docs", "scripts/ai", ".codex", ".github"]
 
 [[document]]
+id = "codex-operation-hardening-plan"
+path = "docs/ai/codex-operation-hardening-plan.md"
+kind = "roadmap"
+authority = "primary"
+code_paths = [".codex", ".githooks", ".github", "build-logic", "app", "data"]
+
+[[document]]
 id = "subagents"
 path = "docs/ai/subagents.md"
 kind = "index"

--- a/docs/ai/registry/documents.toml
+++ b/docs/ai/registry/documents.toml
@@ -212,6 +212,13 @@ authority = "auxiliary"
 code_paths = ["app", "feature"]
 
 [[document]]
+id = "liquid-navigation-ui-follow-up-plan"
+path = "docs/plan/LIQUID_NAVIGATION_UI_FOLLOW_UP_PLAN.md"
+kind = "roadmap"
+authority = "auxiliary"
+code_paths = ["app", "feature/setting", "core/designsystem"]
+
+[[document]]
 id = "unit-test-improvement-plan"
 path = "docs/plan/UNIT_TEST_IMPROVEMENT_PLAN.md"
 kind = "roadmap"

--- a/docs/ai/registry/documents.toml
+++ b/docs/ai/registry/documents.toml
@@ -141,6 +141,13 @@ authority = "primary"
 code_paths = ["AGENTS.md", ".codex", ".gitignore", "docs/ai"]
 
 [[document]]
+id = "code-review"
+path = "docs/ai/code-review.md"
+kind = "policy"
+authority = "primary"
+code_paths = ["AGENTS.md", ".codex/agents", ".githooks", ".github", "docs/ai"]
+
+[[document]]
 id = "subagents"
 path = "docs/ai/subagents.md"
 kind = "index"

--- a/docs/ai/registry/documents.toml
+++ b/docs/ai/registry/documents.toml
@@ -127,6 +127,20 @@ authority = "primary"
 code_paths = [".codex", ".githooks", ".github", "build-logic", "app", "data"]
 
 [[document]]
+id = "cross-project-operation-principles-template"
+path = "docs/ai/cross-project-operation-principles-template.md"
+kind = "template"
+authority = "primary"
+code_paths = ["AGENTS.md", ".codex", ".githooks", ".github", "docs/ai"]
+
+[[document]]
+id = "worktree-policy"
+path = "docs/ai/worktree-policy.md"
+kind = "policy"
+authority = "primary"
+code_paths = ["AGENTS.md", ".codex", ".gitignore", "docs/ai"]
+
+[[document]]
 id = "subagents"
 path = "docs/ai/subagents.md"
 kind = "index"

--- a/docs/ai/subagents.md
+++ b/docs/ai/subagents.md
@@ -1,14 +1,17 @@
 # Codex Subagents
 
-이 문서는 `GithubSearch`에서 Codex subagent를 단계적으로 도입하기 위한 적용 초안이다. subagent는 독립적으로 판단을 위임하는 도구가 아니라, 주 작업자가 놓치기 쉬운 검토 축을 병렬로 확인하는 보조 역할로 사용한다.
+이 문서는 `GithubSearch`에서 실제 운영하는 Codex custom agent의 역할과 공통 계약을 정의한다. 적용된 agent와 정본 문서 연결은 `docs/ai/registry/agents.toml`과 `docs/ai/registry/documents.toml`이 source of truth다. custom agent는 독립적으로 최종 판단을 위임하는 도구가 아니라, 주 작업자가 놓치기 쉬운 검토 축을 확인하는 보조 역할로 사용한다.
 
 ## 공통 운영 규칙
 
-- 주 작업자는 요청 범위, 위험 변경 여부, 최종 적용 여부를 계속 책임진다.
+- 모든 custom agent는 review-first·기본 read-only로 동작한다. 파일 수정은 주 작업자가 명시적으로 위임한 제한된 write scope에서만 가능하다.
+- 모든 custom agent는 결론 전에 관련 primary document와 현재 영향 코드 또는 테스트를 읽고, 결과에 두 근거 경로를 모두 남긴다.
+- 주 작업자는 요청 범위, 위험 변경 여부, 최종 적용 여부, 검증, 최종 보고를 계속 책임진다.
 - subagent에는 한 번에 하나의 명확한 산출물을 요청한다.
 - subagent가 파일 수정을 맡는 경우 write scope를 명시하고, 다른 subagent와 같은 파일을 동시에 수정하지 않는다.
+- 모든 custom agent는 `git add`, `git commit`, `git push`, destructive Git operation을 실행하지 않는다.
 - `local.properties`, keystore, signing config, API key, token, password, `google-services.json` 내용은 읽거나 출력하지 않는다.
-- Room schema, navigation route, public API, Gradle dependency, DI graph 변경은 subagent 결과만으로 바로 적용하지 않고 주 작업자가 별도 위험 변경으로 보고한다.
+- navigation route, public API, module dependency, Gradle, DI graph, Room schema/migration, 대규모 리팩터링, 파일 삭제·이동·이름 변경, generated file 편집은 위험 변경으로 먼저 보고한다. subagent 결과만으로 바로 적용하지 않는다.
 - 최종 응답과 검증 보고는 항상 `docs/ai/change-report-template.md`와 `docs/ai/quality-gates.md`를 따른다.
 - 테스트 전략 판단은 `test-strategy-reviewer`가 우선 담당하며, 다른 subagent는 자기 영역의 구조적 위험만 보고한다.
 - 주 작업자는 `knowledge-operations.md`에 따라 근거·작업 이력·최종 보고를 책임지며, subagent는 그 책임을 대체하지 않는다.
@@ -151,9 +154,44 @@ Android/Kotlin 코드 변경에 필요한 테스트 전략을 리뷰하고, 기�
 - 테스트 실패를 flaky로 단정하지 않고 실패 로그, 변경 범위, 기존 테스트 구조를 근거로 판단한다.
 - 구현 세부 리팩토링보다 테스트로 확인해야 할 observable behavior를 우선 정리한다.
 
-## Initial Rollout Plan
+## Subagent 5: `navigation-contract-reviewer`
 
-1. 문서 초안 단계에서는 위 4개 역할만 사용한다.
-2. 실제 작업에서 subagent를 호출할 때는 요청 문장에 `Use compose-ui-reviewer`, `Use state-flow-architect`, `Use data-domain-boundary-guard`, `Use test-strategy-reviewer`처럼 역할명을 명시한다.
-3. 3~5회 작업 후 중복되는 지시와 빠진 guardrail을 `docs/ai/subagents.md`에 반영한다.
-4. 안정화되면 repository 전용 `.codex` 또는 `.agents` 설정 파일로 승격할지 별도 작업으로 판단한다.
+### Purpose
+
+현재 Compose navigation의 route·argument·호출자/목적지 호환성, back stack, 상태 복원, 화면 전환 테스트 필요성을 검토한다.
+
+### When To Use
+
+- `NavHost`, `composable`, `NavController.navigate`, `navigateUp`, 하단 navigation 변경.
+- route 또는 argument, `from` 같은 출발 화면 구분 값, deep link, back stack, `SavedStateHandle` 전달 경로 변경.
+- 사용자가 "navigation", "route", "deep link", "뒤로 가기", "탭 상태 복원"을 언급한 경우.
+
+### Required Context
+
+- `AGENTS.md`
+- `docs/ai/knowledge-operations.md`
+- `docs/ai/navigation-contracts.md`
+- `docs/ai/task-scope-control.md`
+- `docs/ai/quality-gates.md`
+- `docs/ai/UI_GUIDELINES.md`
+- 변경 파일 목록 또는 diff 요약.
+
+### Output
+
+- 영향받는 호출자와 목적지, route·argument 호환성 점검 결과.
+- back stack, 상태 복원, 하단 navigation 표시, deep link 계약의 위험 여부.
+- 필요한 navigation behavior 검증 시나리오와 가장 좁은 검증 명령.
+- primary document 경로와 현재 코드 또는 테스트 근거 경로.
+
+### Guardrails
+
+- route 제거·이름 변경, argument 계약, deep link, public API, module dependency, Gradle, DI, Room schema/migration, 대규모 리팩터링은 위험 변경으로 먼저 보고한다.
+- 명시적 승인과 rollback 고려 없이 호환 경로를 단순화하거나 제거하지 않는다.
+- 구현·테스트 파일은 주 작업자가 제한된 write scope를 명시했을 때만 수정한다.
+
+## 운영과 재검토
+
+1. 현재 `.codex/agents/`에 compose UI, state/Flow, data/domain, test strategy, navigation contract의 5개 역할이 적용돼 있다.
+2. 실제 작업에서 custom agent를 호출할 때는 요청 문장에 `Use compose-ui-reviewer`, `Use state-flow-architect`, `Use data-domain-boundary-guard`, `Use test-strategy-reviewer`, `Use navigation-contract-reviewer`처럼 역할명을 명시한다. 자동 역할 선택은 하지 않는다.
+3. 각 역할의 범위와 필수 문서는 registry의 `scope`, `required_documents`를 갱신해 관리한다.
+4. 실제 사용 중 중복되는 지시나 빠진 guardrail이 확인되면 이 문서와 agent TOML을 같은 작업에서 함께 갱신한다.

--- a/docs/ai/subagents.md
+++ b/docs/ai/subagents.md
@@ -8,7 +8,7 @@
 - 모든 custom agent는 결론 전에 관련 primary document와 현재 영향 코드 또는 테스트를 읽고, 결과에 두 근거 경로를 모두 남긴다.
 - 주 작업자는 요청 범위, 위험 변경 여부, 최종 적용 여부, 검증, 최종 보고를 계속 책임진다.
 - subagent에는 한 번에 하나의 명확한 산출물을 요청한다.
-- reviewer 결과에는 `Verdict`, primary-document evidence 경로, code/test evidence 경로, finding의 심각도·영향·경로, verification/follow-up, uncertainty를 포함한다.
+- reviewer 결과에는 `Verdict`, review scope, primary-document evidence 경로, code/test evidence 경로, `docs/ai/code-review.md`의 P0~P2 finding 심각도·영향·경로, verification/follow-up, uncertainty를 포함한다.
 - 모든 custom agent는 `git add`, `git commit`, `git push`, destructive Git operation을 실행하지 않는다.
 - `local.properties`, keystore, signing config, API key, token, password, `google-services.json` 내용은 읽거나 출력하지 않는다.
 - navigation route, public API, module dependency, Gradle, DI graph, Room schema/migration, 대규모 리팩터링, 파일 삭제·이동·이름 변경, generated file 편집은 위험 변경으로 먼저 보고한다. subagent 결과만으로 바로 적용하지 않는다.
@@ -34,9 +34,10 @@
 
 ```text
 Verdict: <pass / finding / insufficient context>
+Review scope: <base branch / commit / working-tree diff / requested files>
 Primary-document evidence: <path(s)>
 Code/test evidence: <path(s)>
-Findings: <severity, impact, affected path; none if no finding>
+Findings: <P0/P1/P2, impact, affected path; none if no finding>
 Verification or follow-up: <minimum action>
 Uncertainty: <none or missing evidence>
 ```

--- a/docs/ai/subagents.md
+++ b/docs/ai/subagents.md
@@ -4,17 +4,42 @@
 
 ## 공통 운영 규칙
 
-- 모든 custom agent는 review-first·기본 read-only로 동작한다. 파일 수정은 주 작업자가 명시적으로 위임한 제한된 write scope에서만 가능하다.
+- 모든 custom agent는 review-first·hard read-only로 동작한다. reviewer는 파일을 수정하지 않으며, 구현은 주 작업자 또는 주 작업자가 제한된 write scope를 명시한 별도 worker만 수행한다.
 - 모든 custom agent는 결론 전에 관련 primary document와 현재 영향 코드 또는 테스트를 읽고, 결과에 두 근거 경로를 모두 남긴다.
 - 주 작업자는 요청 범위, 위험 변경 여부, 최종 적용 여부, 검증, 최종 보고를 계속 책임진다.
 - subagent에는 한 번에 하나의 명확한 산출물을 요청한다.
-- subagent가 파일 수정을 맡는 경우 write scope를 명시하고, 다른 subagent와 같은 파일을 동시에 수정하지 않는다.
+- reviewer 결과에는 `Verdict`, primary-document evidence 경로, code/test evidence 경로, finding의 심각도·영향·경로, verification/follow-up, uncertainty를 포함한다.
 - 모든 custom agent는 `git add`, `git commit`, `git push`, destructive Git operation을 실행하지 않는다.
 - `local.properties`, keystore, signing config, API key, token, password, `google-services.json` 내용은 읽거나 출력하지 않는다.
 - navigation route, public API, module dependency, Gradle, DI graph, Room schema/migration, 대규모 리팩터링, 파일 삭제·이동·이름 변경, generated file 편집은 위험 변경으로 먼저 보고한다. subagent 결과만으로 바로 적용하지 않는다.
 - 최종 응답과 검증 보고는 항상 `docs/ai/change-report-template.md`와 `docs/ai/quality-gates.md`를 따른다.
 - 테스트 전략 판단은 `test-strategy-reviewer`가 우선 담당하며, 다른 subagent는 자기 영역의 구조적 위험만 보고한다.
 - 주 작업자는 `knowledge-operations.md`에 따라 근거·작업 이력·최종 보고를 책임지며, subagent는 그 책임을 대체하지 않는다.
+
+## Delegation Matrix
+
+| 작업 조건 | custom agent 사용 | 병렬 수 | write 담당 |
+| --- | --- | --- | --- |
+| Small 변경 또는 단일 파일의 명확한 수정 | 사용하지 않음이 기본 | 0 | main agent |
+| 하나의 전문 검토가 필요한 변경 | 역할 1개를 명시 호출 | 1 | main agent |
+| 서로 겹치지 않는 UI·state·data·navigation·test 조사 | 독립 reviewer를 명시 호출 | 최대 3 | main agent |
+| 구현·리팩터링·테스트 작성 | reviewer는 근거만 반환 | reviewer 최대 3 | main agent 또는 별도 worker 1명 |
+| 같은 파일 또는 같은 동작을 수정하는 병렬 작업 | 금지 | 0 | 한 명의 write 담당 |
+
+- subagent 호출에는 질문, 조사 범위, 영향 파일 또는 diff, 기대 산출물을 함께 제공한다.
+- 사용자가 요청하지 않은 자동 위임은 하지 않는다. main agent는 병렬화가 결과 품질 또는 시간을 실제로 개선하는 독립 작업인지 먼저 판단한다.
+- 별도 worker를 호출할 때도 main agent는 write scope, 검증 명령, 최종 적용 여부를 명시하고 소유한다.
+
+### 공통 결과 형식
+
+```text
+Verdict: <pass / finding / insufficient context>
+Primary-document evidence: <path(s)>
+Code/test evidence: <path(s)>
+Findings: <severity, impact, affected path; none if no finding>
+Verification or follow-up: <minimum action>
+Uncertainty: <none or missing evidence>
+```
 
 ## Subagent 1: `compose-ui-reviewer`
 
@@ -193,5 +218,6 @@ Android/Kotlin 코드 변경에 필요한 테스트 전략을 리뷰하고, 기�
 
 1. 현재 `.codex/agents/`에 compose UI, state/Flow, data/domain, test strategy, navigation contract의 5개 역할이 적용돼 있다.
 2. 실제 작업에서 custom agent를 호출할 때는 요청 문장에 `Use compose-ui-reviewer`, `Use state-flow-architect`, `Use data-domain-boundary-guard`, `Use test-strategy-reviewer`, `Use navigation-contract-reviewer`처럼 역할명을 명시한다. 자동 역할 선택은 하지 않는다.
-3. 각 역할의 범위와 필수 문서는 registry의 `scope`, `required_documents`를 갱신해 관리한다.
-4. 실제 사용 중 중복되는 지시나 빠진 guardrail이 확인되면 이 문서와 agent TOML을 같은 작업에서 함께 갱신한다.
+3. `.codex/config.toml`은 reviewer 병렬 수 같은 project 불변값만 가진다. 모델·reasoning·connector·승인 설정은 사용자 전역 config를 따른다.
+4. 각 역할의 범위와 필수 문서는 registry의 `scope`, `required_documents`를 갱신해 관리한다.
+5. 실제 사용 중 중복되는 지시나 빠진 guardrail이 확인되면 이 문서와 agent TOML을 같은 작업에서 함께 갱신한다.

--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -41,6 +41,14 @@ Template metadata는 `docs/ai/README.md`를 따른다.
 - Documentation Workflow: `문서 작업으로 진행해줘.`
 - Docs Safe Sync Workflow: `android-docs-bootstrap 기준으로 safe sync 해줘.`
 
+## Review Workflow
+
+- review 시작 전에 base branch, 특정 commit, working tree diff, 요청 파일 중 하나로 범위를 선언한다.
+- `docs/ai/code-review.md`의 P0~P2 severity, evidence, false-positive, test-gap 기준을 적용한다.
+- 관련 primary document와 코드·테스트 근거를 함께 확인하고, verdict·scope·evidence·finding·후속 검증·uncertainty를 결과에 남긴다.
+- finding이 없으면 `pass`와 검토 범위를 명시한다. style 선호만으로 finding을 만들지 않는다.
+- reviewer 결과는 read-only 근거이며, main agent 또는 사람이 최종 적용·검증·merge 판단을 수행한다.
+
 ## Documentation Workflow
 
 - 기존 문서를 덮어쓰기 전에 현재 파일을 먼저 읽는다.

--- a/docs/ai/worktree-policy.md
+++ b/docs/ai/worktree-policy.md
@@ -1,0 +1,77 @@
+# Worktree와 Local Android 환경 정책
+
+이 문서는 Codex App managed worktree와 Local checkout 사이에서 GithubSearch 작업을 안전하게 옮기는 기준이다. 정본은 이 문서이며, 일반 작업 규칙은 `AGENTS.md`, 검증 선택은 `docs/ai/quality-gates.md`를 따른다.
+
+## 기본 원칙
+
+- worktree는 Git tracked 파일만으로 가능한 문서, 코드 조사, secret-free compile·test 작업에 사용한다.
+- 현재 ignore된 `local.properties`는 SDK 위치와 credential이 함께 있을 수 있으므로 내용 확인·복사·`.worktreeinclude` 등록을 하지 않는다.
+- OAuth 수동 검증, 실제 계정 호출, 기기 실행, signing, `google-services.json`이 필요한 작업은 Local checkout에서 수행한다.
+- Codex App의 Handoff를 사용해 chat과 변경을 Local 또는 worktree로 옮긴다. 같은 branch를 두 checkout에 동시에 checkout하지 않는다.
+
+Codex managed worktree는 기본적으로 Git checkout에서 시작하며, `.worktreeinclude`에 적힌 ignore 파일만 추가 복사할 수 있다. 이 repository는 해당 기능을 기본 사용하지 않는다. [Codex Worktrees](https://learn.chatgpt.com/docs/environments/git-worktrees.md)
+
+## 작업 위치 선택
+
+| 작업 종류 | 기본 위치 | 이유 |
+| --- | --- | --- |
+| 문서, registry, agent policy, 코드 읽기·review | Worktree 또는 Local | tracked 파일만으로 수행 가능 |
+| unit test, compile, lint, APK build | Worktree 가능 | Android SDK를 별도로 안전하게 준비하고, 실제 credential이 아닌 placeholder로 충분한 경우에만 수행 |
+| OAuth 로그인·토큰 폐기·실제 API 호출 | Local | 실제 credential과 사용자 계정·redirect 환경이 필요 |
+| emulator/실기기 확인, signing, Firebase·Google service 확인 | Local | machine-specific 설정 또는 민감한 ignore 파일이 필요할 수 있음 |
+| 기존 IDE 상태·실행 중인 앱을 이용한 확인 | Local handoff | 기존 개발 환경을 그대로 사용 |
+
+## Worktree 시작 전 확인
+
+1. 기준 branch와 현재 Local의 unstaged 변경을 확인한다. Local 변경을 포함한 branch에서 worktree를 시작하면 변경도 함께 적용될 수 있다.
+2. 작업이 tracked 파일과 secret-free 입력만으로 가능한지 판단한다.
+3. 필요한 Android SDK 위치, emulator, credential, signing 설정을 worktree로 복사하지 않아도 되는지 확인한다.
+4. branch가 이미 다른 checkout에서 사용 중이면 새 branch를 만들거나 Handoff를 사용한다.
+
+## Worktree에서 허용하는 검증
+
+- 문서 관계 검사: knowledge Index, graph verifier, 정책 script test
+- source inspection, formatter·static analysis
+- Android compile·unit test·APK build: 사용자가 안전한 SDK 환경을 준비했고 실제 credential이 필요하지 않을 때만 가능
+- Phase 2에서 검증한 non-secret placeholder 입력을 사용한 Gradle 검증
+
+worktree에서 Android build가 SDK 경로 또는 local 설정 부재로 실패하면 기존 `local.properties`를 복사하지 않는다. Local handoff를 선택하거나, credential을 포함하지 않는 별도 환경 준비 방법을 저장소 관리자와 검토한다.
+
+## Local handoff 기준
+
+다음 중 하나면 Codex App의 **Hand off → Local**을 사용한다.
+
+- 실제 OAuth 또는 네트워크 인증 흐름을 확인해야 한다.
+- emulator·실기기·Android Studio의 기존 상태가 필요하다.
+- signing, keystore, Google service 설정 등 ignore된 machine-specific 파일이 필요하다.
+- worktree의 branch를 현재 Local checkout에서 직접 사용해야 한다.
+
+Handoff는 Git 작업을 관리하지만 ignore 파일의 내용을 안전한 credential로 바꾸지 않는다. Local에서 검증한 뒤에도 secret 값, token, `local.properties` 내용은 chat·문서·commit에 기록하지 않는다.
+
+## `.worktreeinclude` 금지 기본값과 예외
+
+현재 repository에는 `.worktreeinclude`를 만들지 않는다. 특히 아래 경로·패턴은 등록하지 않는다.
+
+- `local.properties`
+- keystore·signing 설정
+- `.env*`, token, API key, OAuth credential
+- `google-services.json`
+- Android SDK·emulator·IDE의 개인 설정
+
+향후 반드시 필요해질 경우에는 별도 Risky Change로 처리한다. 추가 전에 저장소 관리자가 대상이 credential을 포함하지 않는 독립 파일임을 확인하고, 복사 범위·rollback·새 worktree 검증 결과를 작업 이력에 남겨야 한다.
+
+## Branch와 cleanup
+
+- Git branch는 한 checkout에서만 checkout한다. worktree에서 branch를 만들었다면 Local에서 같은 branch를 checkout하지 말고 Handoff 또는 다른 branch를 사용한다.
+- managed worktree는 임시 환경으로 취급한다. 커밋·push가 필요한 변경은 branch를 만든 뒤 수행하고, 장기 환경이 필요하면 permanent worktree를 명시적으로 만든다.
+- worktree 삭제·정리는 현재 작업과 branch 상태를 확인한 뒤 수행한다. Local의 변경과 ignore 파일을 정리 대상으로 간주하지 않는다.
+
+## 완료 보고
+
+worktree 작업의 Change Report에는 다음을 구분해 적는다.
+
+- 작업 위치: Worktree 또는 Local handoff
+- worktree에서 실행한 검증과 결과
+- Local에서만 가능한 검증과 그 이유
+- secret·ignore 파일을 복사하거나 출력하지 않았다는 확인
+- branch 또는 handoff 관련 후속 조치

--- a/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase0.md
+++ b/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase0.md
@@ -1,0 +1,58 @@
+---
+id: GS-2026-0009
+status: completed
+base_commit: 2147a3e
+related_documents: [knowledge-operations, task-scope, quality-gates, codex-operation-hardening-plan, history-readme]
+related_code: [.codex/agents, .githooks, .github/workflows, build-logic, app, data]
+skills_used: [project-knowledge-grounding, session-retrospective]
+---
+
+# Codex 운영 보강 Phase 0 결정과 책임 분리
+
+## 요청
+
+- Codex 운영 보강 명세의 Phase 0을 적용하고, reviewer·main agent·CI·worktree·관리자 권한의 책임과 후속 변경을 분리한다.
+
+## 근거
+
+- 현재 5개 reviewer는 review-first 정책을 가지지만 TOML sandbox가 아직 hard read-only가 아니다.
+- `.githooks/pre-commit`과 `knowledge.yml`은 각각 staged 변경과 PR 지식 관계를 검사한다. `build.yml`은 verify, PR comment, Pages deploy 권한을 한 job에 둔다.
+- `local.properties`는 ignore된 local 파일임만 확인했고, 내용은 읽거나 기록하지 않았다.
+- 공식 Codex 가이드의 durable guidance, bounded subagent, least privilege, worktree 원칙을 phase 명세의 근거로 사용했다.
+
+## 결정
+
+- reviewer의 hard read-only 전환은 Phase 1, CI 권한·OAuth secret 제거는 Phase 2, worktree local 설정 문서는 Phase 3, 공통 review 기준은 Phase 4로 분리한다.
+- 현재 runtime 정본은 기존 `AGENTS.md`, `subagents.md`, agent TOML로 유지한다. Phase 0은 후속 정책의 승인·책임 경계만 적용한다.
+- repository에는 팀 공통 불변값만 두고, 개인 모델·reasoning·connector·승인 설정은 사용자 전역 config에 남긴다.
+- GitHub Actions 권한, secret, Pages, branch protection은 저장소 관리자와 명시적 Risky Change 승인 없이는 변경하지 않는다.
+
+## 변경
+
+- 운영 보강 명세 상태를 `Phase 0 completed, Phase 1 pending`으로 바꿨다.
+- main agent, reviewer, Codex config, Git hook, knowledge CI, build CI, worktree, 저장소 관리자별 책임·현재 상태·후속 phase를 표로 분리했다.
+- Phase 0 체크리스트와 실행 결과를 완료 상태로 기록했다.
+
+## 검증
+
+- `python3 scripts/ai/generate_knowledge_index.py --check`: 통과.
+- `python3 scripts/ai/verify_knowledge_graph.py`: 통과.
+- `python3 -m unittest discover -s scripts/ai/tests -p 'test_*.py'`: 문서·registry 검증 회귀 11 tests 통과.
+- `git diff --check`: 통과.
+- 문서·registry·generated Index만 변경했으며 Android code, Gradle, CI runtime은 바꾸지 않아 Gradle 검증은 실행하지 않았다.
+
+## 지시 이행
+
+- 충족: Phase 0을 후속 구현과 분리해 정책 결정·책임·승인 경계만 적용했다.
+- 충족: reviewer, CI, worktree, 관리자 책임을 각각 다른 phase로 분리했다.
+- 충족: `local.properties`와 사용자 untracked migration template의 내용을 변경·stage·commit하지 않았다.
+- 충족: commit·push·GitHub 원격 설정 변경을 수행하지 않았다.
+
+## 스킬 평가
+
+- `project-knowledge-grounding`: 현재 agent, hook, CI, build 설정을 정책 분리의 근거로 고정했다.
+- `session-retrospective`: history·registry·generated Index·graph 검증과 사용자 local 파일 보존을 종료 전에 점검했다.
+
+## 개선 후보
+
+- Phase 1에서 hard read-only TOML을 적용할 때 reviewer 한 개로 parent runtime permission과의 실제 동작을 수동 확인한다.

--- a/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase1.md
+++ b/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase1.md
@@ -1,0 +1,60 @@
+---
+id: GS-2026-0010
+status: completed
+base_commit: 5a9f45d
+related_documents: [knowledge-operations, task-scope, quality-gates, subagents, codex-operation-hardening-plan, history-readme]
+related_code: [.codex/config.toml, .codex/agents, docs/ai, AGENTS.md]
+skills_used: [project-knowledge-grounding, session-retrospective]
+---
+
+# Codex 운영 보강 Phase 1 reviewer 권한과 위임 정책
+
+## 요청
+
+- Phase 0 커밋 후 reviewer를 hard read-only로 고정하고, bounded subagent 위임 정책을 적용한다.
+
+## 근거
+
+- Phase 0 명세는 reviewer를 hard read-only로 고정하고, 구현은 main agent 또는 별도 worker만 담당하도록 결정했다.
+- 현재 5개 reviewer TOML은 review-first·근거 경로·Git·secret·위험 변경 guardrail을 이미 가졌지만 `sandbox_mode`를 명시하지 않았다.
+- 공식 Codex custom agent 설정은 agent TOML의 `sandbox_mode`와 project config의 `[agents]` 동시 실행 수를 지원한다. project에는 모델·reasoning·connector 같은 개인 설정을 고정하지 않는다.
+
+## 결정
+
+- 5개 reviewer를 `sandbox_mode = "read-only"`로 고정한다. parent의 제한된 write 위임 예외는 reviewer에서 제거하고, 구현은 main agent 또는 별도 worker로 분리한다.
+- project config에는 `max_concurrent_threads_per_session = 3`만 설정한다. 모델·reasoning·connector·승인 설정은 사용자 전역 config에 남긴다.
+- Small 변경은 main agent 단독으로 처리하고, 독립된 read-only 조사만 최대 3개 병렬화한다. 같은 파일·동작의 병렬 write는 금지한다.
+
+## 변경
+
+- `.codex/config.toml`을 추가해 reviewer 최대 병렬 수를 3으로 제한했다.
+- 5개 reviewer TOML에 hard read-only sandbox와 공통 evidence/finding 결과 형식을 추가했다.
+- `AGENTS.md`, `subagents.md`에 main agent/worker/reviewer 책임, 명시적 위임, delegation matrix, 공통 결과 형식을 반영했다.
+- 운영 보강 명세의 Phase 1을 applied 상태로 갱신했다.
+
+## 검증
+
+- `python3 scripts/ai/generate_knowledge_index.py --check`: 통과. shared 35개·local 3개 문서를 확인했다.
+- `python3 scripts/ai/verify_knowledge_graph.py`: 0 error, 0 warning 통과.
+- `python3 -m unittest discover -s scripts/ai/tests -p 'test_*.py'`: 11 tests 통과.
+- `rg -n '^sandbox_mode = "read-only"$' .codex/agents/*.toml`: 5개 reviewer 설정을 확인했다.
+- `rg -n '^max_concurrent_threads_per_session = 3$' .codex/config.toml`: project 병렬 수 설정을 확인했다.
+- `git diff --check`: 통과.
+- `compose-ui-reviewer`를 명시 호출해 `Verdict`, 문서·코드 evidence 경로, findings, follow-up, uncertainty를 반환하는 것을 확인했다. reviewer 실행 전후 working tree에 reviewer의 추가 파일 변경이 없었다.
+- Android code·Gradle·CI runtime은 바꾸지 않아 Gradle 검증은 실행하지 않았다.
+
+## 지시 이행
+
+- 충족: Phase 0 문서를 커밋한 뒤 별도 Phase 1 작업으로 reviewer 권한·위임 정책을 적용했다.
+- 충족: reviewer read-only sandbox, 최대 병렬 수, main agent/worker 책임, evidence 중심 결과 형식을 분리했다.
+- 충족: `compose-ui-reviewer` runtime 호출이 파일 수정 없이 공통 결과 형식과 근거 경로를 반환하는 것을 확인했다.
+- 충족: 사용자 untracked `docs/multi-module-migration-template.md`를 변경·stage·commit하지 않았다.
+
+## 스킬 평가
+
+- `project-knowledge-grounding`: Phase 0 결정과 현재 TOML·운영 문서의 차이를 확인해 최소 설정 변경으로 한정했다.
+- `session-retrospective`: generated Index, graph·회귀 검사, 설정 line 확인과 runtime 검증의 남은 조건을 종료 전에 구분했다.
+
+## 개선 후보
+
+- runtime reviewer는 `SettingScreen` 하단 overlay 여백, Liquid navigation의 `selectableGroup`, Light/Dark Preview·UI regression fixture를 개선 후보로 보고했다. 이는 Phase 1 설정과 분리된 UI 변경이므로 별도 작업에서 검토한다.

--- a/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase2.md
+++ b/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase2.md
@@ -1,0 +1,60 @@
+---
+id: GS-2026-0011
+status: in_progress
+base_commit: 81aa58f
+related_documents: [knowledge-operations, task-scope, quality-gates, codex-operation-hardening-plan, history-readme]
+related_code: [.github/workflows/build.yml, build-logic, app, data]
+skills_used: [project-knowledge-grounding, session-retrospective]
+---
+
+# Codex 운영 보강 Phase 2 CI 최소 권한과 secret-free 검증
+
+## 요청
+
+- Phase 2로 진행해 GitHub Actions verify·PR comment·Pages deploy 권한을 분리하고, production OAuth secret 없이 build를 검증한다.
+
+## 근거
+
+- 기존 `build` job은 code checkout·Gradle 실행·PR 댓글·Pages 배포에 `contents: write`, `pull-requests: write`, `pages: write`, `id-token: write`를 함께 부여했다.
+- `app`은 `CLIENT_ID`, `CLIENT_SECRET`, `REDIRECT_URI`를, `data`는 앞의 두 값을 BuildConfig로 요구한다. `build-logic`은 local property, Gradle property, 환경 변수 순으로 값을 찾는다.
+- GitHub Actions 공식 권한 최소화와 Pages custom workflow 권한 문서를 기준으로, 실행 job과 쓰기 권한 job을 분리했다.
+
+## 결정
+
+- verify는 `contents: read`와 비밀이 아닌 고정 placeholder만 사용한다.
+- JaCoCo 댓글은 internal PR 전용 별도 job으로 분리하고 fork PR에서는 실행하지 않는다.
+- Pages upload·deploy는 `main`·`develop` push 전용 별도 job으로 분리한다. deploy job은 build artifact만 받아 source checkout·Gradle 실행을 하지 않는다.
+- `pull_request_target`은 도입하지 않는다.
+
+## 변경
+
+- `.github/workflows/build.yml`에서 production OAuth secret과 Gradle cache encryption secret 사용, secret 검증 step, build job의 write 권한을 제거했다.
+- JaCoCo report와 Pages package를 일반 artifact로 전달하고, 댓글·배포를 별도 최소 권한 job으로 분리했다.
+- `docs/ai/quality-gates.md`에 일반 PR, fork PR, protected branch push별 실행 경로·권한·경계를 기록했다.
+- `docs/ai/codex-operation-hardening-plan.md`에 Phase 2 완료 항목과 관리자 후속 항목을 반영했다.
+
+## 검증
+
+- clean temporary worktree에서 non-secret placeholder와 Android SDK 경로를 제공해 CI full Gradle command를 실행했고 JaCoCo full report 생성까지 확인했다.
+- `ruby -ryaml -e 'YAML.load_file(".github/workflows/build.yml")'`: 통과.
+- production OAuth·Gradle cache encryption secret·`pull_request_target` 참조 부재와 placeholder 존재를 정적 검사했다.
+- `python3 scripts/ai/generate_knowledge_index.py --check`: 통과.
+- `python3 scripts/ai/verify_knowledge_graph.py`: 0 error, 0 warning.
+- `python3 -m unittest discover -s scripts/ai/tests -p 'test_*.py'`: 11 tests 통과.
+- `actionlint`는 현재 local 환경에 설치되어 있지 않아 실행하지 못했다. YAML parser와 원격 PR workflow로 보완한다.
+- 원격 PR workflow 실행과 required status 지정은 아직 수행 전이다.
+
+## 지시 이행
+
+- fulfilled: Phase 2 CI 최소 권한·secret-free 검증·댓글/Pages 분리를 적용했다.
+- partial: 원격 GitHub Actions 실행 확인과 required status 지정은 PR 생성 후 저장소 관리자 권한이 필요하다.
+
+## 스킬 평가
+
+- `project-knowledge-grounding`: workflow, BuildConfig 입력, plan·quality gate를 함께 확인해 placeholder 범위를 정하는 데 충분했다.
+- `session-retrospective`: history record, generated index, graph 검증을 종료 기준으로 유지한다.
+
+## 개선 후보
+
+- 원격 workflow에서 artifact download가 최소 권한 job에서도 동작하는지 확인한다. 실패하면 권한을 넓히지 않고 GitHub 공식 action의 artifact 접근 요구사항을 근거로 최소 수정한다.
+- 원격 실행이 안정화되면 저장소 관리자가 `Knowledge verification`과 build verify status를 required status로 지정한다.

--- a/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase2.md
+++ b/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase2.md
@@ -1,6 +1,6 @@
 ---
 id: GS-2026-0011
-status: in_progress
+status: completed
 base_commit: 81aa58f
 related_documents: [knowledge-operations, task-scope, quality-gates, codex-operation-hardening-plan, history-readme]
 related_code: [.github/workflows/build.yml, build-logic, app, data]
@@ -42,12 +42,14 @@ skills_used: [project-knowledge-grounding, session-retrospective]
 - `python3 scripts/ai/verify_knowledge_graph.py`: 0 error, 0 warning.
 - `python3 -m unittest discover -s scripts/ai/tests -p 'test_*.py'`: 11 tests 통과.
 - `actionlint`는 현재 local 환경에 설치되어 있지 않아 실행하지 못했다. YAML parser와 원격 PR workflow로 보완한다.
-- 원격 PR workflow 실행과 required status 지정은 아직 수행 전이다.
+- draft PR #161에서 `Knowledge verification`, `Build & Coverage`, `JaCoCo PR Comment`가 성공했고 `Deploy Coverage Pages`는 PR에서 skipped 됐다.
+- required status 지정은 저장소 관리자 후속 작업이다.
 
 ## 지시 이행
 
 - fulfilled: Phase 2 CI 최소 권한·secret-free 검증·댓글/Pages 분리를 적용했다.
-- partial: 원격 GitHub Actions 실행 확인과 required status 지정은 PR 생성 후 저장소 관리자 권한이 필요하다.
+- fulfilled: draft PR #161에서 verify·knowledge workflow와 PR coverage comment의 원격 동작을 확인했다.
+- partial: required status 지정은 저장소 관리자 권한이 필요하다.
 
 ## 스킬 평가
 
@@ -56,5 +58,5 @@ skills_used: [project-knowledge-grounding, session-retrospective]
 
 ## 개선 후보
 
-- 원격 workflow에서 artifact download가 최소 권한 job에서도 동작하는지 확인한다. 실패하면 권한을 넓히지 않고 GitHub 공식 action의 artifact 접근 요구사항을 근거로 최소 수정한다.
-- 원격 실행이 안정화되면 저장소 관리자가 `Knowledge verification`과 build verify status를 required status로 지정한다.
+- 최소 권한 `coverage-comment` job의 artifact download와 PR comment 동작은 draft PR #161에서 확인했다.
+- 저장소 관리자가 `Knowledge verification`과 build verify status를 required status로 지정한다.

--- a/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase3.md
+++ b/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase3.md
@@ -1,0 +1,55 @@
+---
+id: GS-2026-0013
+status: completed
+base_commit: b6bba07
+related_documents: [root-agents, ai-readme, knowledge-operations, quality-gates, codex-operation-hardening-plan, worktree-policy, history-readme]
+related_code: [.gitignore, .codex, docs/ai]
+skills_used: [project-knowledge-grounding, session-retrospective]
+---
+
+# Codex 운영 보강 Phase 3 Worktree와 Local Android 환경 정책
+
+## 요청
+
+- Phase 3로 진행해 Codex App worktree가 local OAuth 값이나 machine-specific 설정을 복사하지 않도록 정책을 적용한다.
+
+## 근거
+
+- `local.properties`는 ignore된 local 파일이고, `.worktreeinclude`는 존재하지 않는다. 파일 내용은 읽지 않았다.
+- 공식 Codex worktree 지침은 `.worktreeinclude`가 managed worktree에 ignore 파일을 복사할 수 있고, Handoff가 Local/worktree 간 Git 작업을 처리하며 같은 branch는 한 checkout에서만 checkout할 수 있음을 설명한다.
+- Android SDK, OAuth, signing, device 검증은 repository마다 local 설정 의존성이 다르다.
+
+## 결정
+
+- `.worktreeinclude`를 새로 만들지 않는다.
+- default worktree는 tracked 파일과 non-secret 입력만으로 가능한 문서·조사·검증에 제한한다.
+- 실제 OAuth, 기기, signing, Google service 검증은 Local handoff로 분리한다.
+
+## 변경
+
+- `docs/ai/worktree-policy.md`에 작업 위치 선택, worktree 시작 전 확인, 허용 검증, Local handoff, `.worktreeinclude` 예외, branch·cleanup, 완료 보고 기준을 작성했다.
+- `AGENTS.md`, AI docs README, registry, operation hardening plan에 이 정책을 연결하고 Phase 3 완료 상태를 반영했다.
+- Phase 2 history에 draft PR #161의 원격 CI 성공 결과를 기록했다.
+
+## 검증
+
+- `python3 scripts/ai/generate_knowledge_index.py --check`: 통과.
+- `python3 scripts/ai/verify_knowledge_graph.py`: 0 error, 0 warning.
+- `git diff --check`: 통과.
+- 문서-only 변경이므로 Gradle 검증은 실행하지 않았다.
+
+## 지시 이행
+
+- fulfilled: secret 복사를 지시하지 않는 worktree·Local handoff 정책을 문서화했다.
+- fulfilled: `.worktreeinclude`와 `local.properties`를 추가·수정·내용 확인하지 않았다.
+
+## 스킬 평가
+
+- `project-knowledge-grounding`: ignore 상태, 기존 phase 명세, Android 검증 경계를 함께 확인하는 데 사용했다.
+- `session-retrospective`: history·registry·generated Index 관계를 종료 기준으로 적용한다.
+- `openai-docs`: 최신 Codex manual의 managed worktree, Handoff, `.worktreeinclude`, branch 제한 지침을 확인하는 데 사용했다.
+
+## 개선 후보
+
+- Phase 5에서 실제 신규 managed worktree와 Local handoff 사례를 회고해 정책이 과도하거나 부족한지 점검한다.
+- credential-free SDK 설정 파일을 분리해야 할 요구가 생기면 별도 Risky Change로 설계·승인한다.

--- a/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase4.md
+++ b/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase4.md
@@ -1,0 +1,57 @@
+---
+id: GS-2026-0014
+status: completed
+base_commit: 918653b
+related_documents: [root-agents, ai-readme, workflows, subagents, knowledge-operations, codex-operation-hardening-plan, code-review, history-readme]
+related_code: [.codex/agents, .githooks, .github, docs/ai]
+skills_used: [project-knowledge-grounding, session-retrospective]
+---
+
+# Codex 운영 보강 Phase 4 공통 Code Review 기준과 lifecycle hook 경계
+
+## 요청
+
+- Phase 4로 진행해 custom reviewer, Codex `/review`, 사람 PR review가 공통 결과 기준을 사용하도록 하고 hook 책임 경계를 문서화한다.
+
+## 근거
+
+- 현재 custom reviewer는 Verdict·문서/코드 근거·finding·follow-up 형식을 사용하지만 P0~P2 severity와 review scope를 공통 정본으로 정의하지 않았다.
+- Git pre-commit hook과 Knowledge CI가 formatter·Index·graph의 기계적 검증을 이미 담당한다.
+- 공식 Codex hook은 세션·도구 사용 주기 확장 수단이며 project-local hook은 신뢰 검토가 필요하다.
+
+## 결정
+
+- review scope, P0~P2, evidence, false-positive, test-gap, common output을 별도 primary policy로 정의한다.
+- 같은 검증을 lifecycle hook으로 중복하지 않고, 실제 반복 누락 사례가 확인될 때만 별도 승인 작업으로 hook을 도입한다.
+
+## 변경
+
+- `docs/ai/code-review.md`에 review scope, P0~P2, evidence, false-positive, test-gap, common output, hook 경계를 작성했다.
+- `AGENTS.md`, Review Workflow, subagent 문서와 다섯 reviewer TOML에 공통 review scope·P0~P2 결과 형식을 연결했다.
+- lifecycle hook 설정이나 실행 스크립트는 추가하지 않았다.
+
+## 검증
+
+- `compose-ui-reviewer`가 Liquid navigation 후보를 read-only로 검토해 Verdict·scope·문서/코드 근거·P2 finding·후속 조치·uncertainty를 반환했다.
+- reviewer 실행 뒤 main agent가 의도한 policy·agent 문서 외 reviewer가 만든 파일 변경이 없음을 확인했다.
+- `python3 scripts/ai/generate_knowledge_index.py --check`: 통과.
+- `python3 scripts/ai/verify_knowledge_graph.py`: 0 error, 0 warning.
+- `git diff --check`: 통과.
+- `.codex/hooks.json`은 존재하지 않아 lifecycle hook 설정을 추가하지 않았음을 확인했다.
+- 현재 `python3`은 3.9.6으로 표준 `tomllib`가 없어 agent TOML의 별도 parser 검증은 실행하지 못했다. 의존성을 추가하지 않고 graph 검증과 변경 diff 검토로 확인했다.
+- 문서·agent 지시 변경이므로 Gradle 검증은 실행하지 않는다.
+
+## 지시 이행
+
+- fulfilled: custom reviewer, `/review`, 사람 review의 공통 severity·evidence·test-gap 기준을 문서화했다.
+- fulfilled: existing Git hook·CI와 같은 검사를 lifecycle hook으로 중복하지 않았고, 반복 누락 근거가 없어 hook을 추가하지 않았다.
+
+## 스킬 평가
+
+- `project-knowledge-grounding`: 기존 reviewer 형식, Git hook·CI 책임, history 근거를 함께 확인하는 데 사용했다.
+- `session-retrospective`: reviewer 결과·working tree·registry 관계를 완료 기준으로 적용한다.
+- `openai-docs`: 최신 Codex lifecycle hook의 신뢰 검토와 이벤트 경계를 확인하는 데 사용했다.
+
+## 개선 후보
+
+- Phase 5에서 실제 PR review 3~5건을 회고해 P0~P2 일관성, false-positive, test-gap 품질과 lifecycle hook 필요성을 다시 판단한다.

--- a/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase5.md
+++ b/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase5.md
@@ -1,0 +1,53 @@
+---
+id: GS-2026-0015
+status: in_progress
+base_commit: ea99589
+related_documents: [codex-operation-hardening-plan, worktree-policy, code-review, quality-gates, knowledge-operations, history-readme]
+related_code: [.github, .githooks, .codex, docs/ai]
+skills_used: [project-knowledge-grounding, session-retrospective]
+---
+
+# Codex 운영 보강 Phase 5 운영 정착과 관리자 확인
+
+## 요청
+
+- Phase 4 커밋 뒤 Phase 5 운영 정착 단계로 진행한다.
+
+## 근거
+
+- Phase 0~4는 각각 completed history record와 독립 commit을 갖는다.
+- draft PR #161은 remote commit `b6bba07`에서 Build·Knowledge·JaCoCo PR comment 성공과 Pages deploy skip을 확인했다. Phase 3·4 commit은 아직 local branch에만 있다.
+- `develop` branch protection 조회 결과 required status는 설정되지 않았다.
+- `github-pages` environment에는 branch policy가 있으나 protected branch 전용은 아니다.
+- 실제 managed worktree의 Android 검증·Local handoff 반복 사례와 review 품질 3~5건 회고는 아직 충분하지 않다.
+
+## 결정
+
+- branch protection, required status, Pages environment를 자동 변경하지 않는다.
+- Phase 3·4 commit을 PR에 올린 뒤 CI를 다시 확인하고, 반복 작업 근거가 쌓일 때까지 Phase 5를 in_progress로 유지한다.
+
+## 변경
+
+- operation hardening plan에 Phase 5의 현재 PR, branch protection, Pages environment, 회고 대기 상태를 기록했다.
+
+## 검증
+
+- PR #161의 workflow 성공과 remote head를 확인했다.
+- branch protection과 Pages environment 설정을 read-only로 조회했다.
+- 진행 중인 운영 phase이므로 후속 push·PR CI·관리자 설정은 아직 완료되지 않았다.
+
+## 지시 이행
+
+- partial: 운영 점검을 시작하고 외부 관리자 작업과 반복 사례 부족을 명시했다.
+- not fulfilled: required status 지정, Pages policy 최종 확인, 반복 worktree·review 회고는 후속 작업이 필요하다.
+
+## 스킬 평가
+
+- `project-knowledge-grounding`: phase 명세, history, 현재 branch·PR 상태를 연결하는 데 사용했다.
+- `session-retrospective`: Phase 5가 완료 조건을 충족하지 않았음을 이력에 명확히 남기도록 사용한다.
+
+## 개선 후보
+
+- Phase 3·4 push 후 PR CI 결과를 기록한다.
+- 저장소 관리자가 required status와 Pages environment branch policy를 검토한 뒤 결정을 기록한다.
+- managed worktree와 Local handoff 사례, review 3~5건을 누적해 정책의 효과·과도함을 회고한다.

--- a/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase5.md
+++ b/docs/history/records/2026/2026-08-01-codex-operation-hardening-phase5.md
@@ -16,30 +16,32 @@ skills_used: [project-knowledge-grounding, session-retrospective]
 ## 근거
 
 - Phase 0~4는 각각 completed history record와 독립 commit을 갖는다.
-- draft PR #161은 remote commit `b6bba07`에서 Build·Knowledge·JaCoCo PR comment 성공과 Pages deploy skip을 확인했다. Phase 3·4 commit은 아직 local branch에만 있다.
-- `develop` branch protection 조회 결과 required status는 설정되지 않았다.
-- `github-pages` environment에는 branch policy가 있으나 protected branch 전용은 아니다.
+- draft PR #161은 remote commit `3bc4acd`에서 Build·Knowledge·JaCoCo PR comment 성공과 Pages deploy skip을 확인했다.
+- 저장소 관리자가 `develop` branch ruleset을 생성해 PR과 `Build & Coverage`, `Generated index and graph`를 병합 조건으로 지정했다.
+- `github-pages` environment는 `develop`만 허용한다. 기존 workflow는 `main`·`develop` 모두에서 하나의 Pages 사이트를 배포할 수 있어, 마지막 배포가 이전 커버리지 리포트를 덮어쓸 수 있었다.
 - 실제 managed worktree의 Android 검증·Local handoff 반복 사례와 review 품질 3~5건 회고는 아직 충분하지 않다.
 
 ## 결정
 
 - branch protection, required status, Pages environment를 자동 변경하지 않는다.
-- Phase 3·4 commit을 PR에 올린 뒤 CI를 다시 확인하고, 반복 작업 근거가 쌓일 때까지 Phase 5를 in_progress로 유지한다.
+- `main`은 build 검증만, `develop`은 build와 Pages 배포를 수행하도록 workflow를 조정한다.
+- workflow 변경을 PR에 올린 뒤 CI를 다시 확인하고, 반복 작업 근거가 쌓일 때까지 Phase 5를 in_progress로 유지한다.
 
 ## 변경
 
-- operation hardening plan에 Phase 5의 현재 PR, branch protection, Pages environment, 회고 대기 상태를 기록했다.
+- operation hardening plan에 최신 PR CI, 사용자 완료 관리자 설정, Pages 단일 배포 브랜치 결정을 기록했다.
+- `build.yml`의 Pages artifact·deploy 조건을 `develop` push 전용으로 조정하고, quality gate와 JaCoCo 계획을 같은 운영 기준으로 맞췄다.
 
 ## 검증
 
-- PR #161의 workflow 성공과 remote head를 확인했다.
-- branch protection과 Pages environment 설정을 read-only로 조회했다.
-- 진행 중인 운영 phase이므로 후속 push·PR CI·관리자 설정은 아직 완료되지 않았다.
+- PR #161의 최신 CI 성공과 remote head를 확인했다.
+- branch protection과 Pages environment 설정은 사용자 작업·read-only 조회로 확인했다. 이번 workflow 변경의 원격 CI는 push 후 다시 확인한다.
+- 진행 중인 운영 phase이므로 반복 worktree·review 회고는 아직 완료되지 않았다.
 
 ## 지시 이행
 
-- partial: 운영 점검을 시작하고 외부 관리자 작업과 반복 사례 부족을 명시했다.
-- not fulfilled: required status 지정, Pages policy 최종 확인, 반복 worktree·review 회고는 후속 작업이 필요하다.
+- partial: 운영 점검을 시작하고 required status·Pages 배포 브랜치 결정을 반영했다.
+- not fulfilled: 이번 workflow 변경의 원격 CI, 반복 worktree·review 회고는 후속 작업이 필요하다.
 
 ## 스킬 평가
 
@@ -48,6 +50,5 @@ skills_used: [project-knowledge-grounding, session-retrospective]
 
 ## 개선 후보
 
-- Phase 3·4 push 후 PR CI 결과를 기록한다.
-- 저장소 관리자가 required status와 Pages environment branch policy를 검토한 뒤 결정을 기록한다.
+- 이번 workflow 변경을 push한 뒤 PR CI 결과와 `develop` push Pages 배포를 기록한다.
 - managed worktree와 Local handoff 사례, review 3~5건을 누적해 정책의 효과·과도함을 회고한다.

--- a/docs/history/records/2026/2026-08-01-codex-operation-hardening-plan.md
+++ b/docs/history/records/2026/2026-08-01-codex-operation-hardening-plan.md
@@ -1,0 +1,61 @@
+---
+id: GS-2026-0008
+status: completed
+base_commit: 2147a3e
+related_documents: [knowledge-operations, task-scope, quality-gates, subagents, codex-operation-hardening-plan, history-readme]
+related_code: [.codex/agents, .githooks, .github/workflows, build-logic, app, data]
+skills_used: [project-knowledge-grounding, session-retrospective]
+---
+
+# Codex 운영 정책 보강 명세
+
+## 요청
+
+- GithubSearch의 현재 Codex 운영 정책을 공식 Codex 가이드와 비교하고, 부족한 부분을 단계별 실행 명세와 체크리스트로 문서화한다.
+
+## 근거
+
+- 최신 공식 Codex manual에서 `AGENTS.md`, custom agent·subagent, hook, worktree, configuration의 운영 원칙을 확인했다. 전역 `openai-docs` system skill은 project skill registry 대상이 아니므로 frontmatter의 `skills_used`에는 기록하지 않고 이 본문에만 사용 근거를 남긴다.
+- `AGENTS.md`, `knowledge-operations.md`, `task-scope-control.md`, `quality-gates.md`, agent registry와 현재 5개 agent TOML을 함께 읽었다.
+- `.github/workflows/build.yml`은 build·coverage comment·Pages deploy를 하나의 job에서 실행하며 `contents: write`, `pull-requests: write`, `pages: write`, `id-token: write`를 모두 부여한다. 반면 `knowledge.yml`은 `contents: read`만 사용한다.
+- `build-logic`의 `getApiKey`는 local properties, Gradle property, 환경 변수 순으로 값을 찾고, app·data BuildConfig가 OAuth 값을 요구한다. 따라서 CI secret 제거는 non-secret placeholder build 검증과 함께 계획해야 한다.
+- `local.properties`는 존재하지만 Git ignore 대상이며 `.worktreeinclude`는 없다. 파일 내용은 읽거나 기록하지 않았다.
+
+## 결정
+
+- 구현 변경 없이 policy·phase·승인 지점을 먼저 고정한다.
+- reviewer는 hard read-only로, 구현은 main agent 또는 명시적인 worker로 분리하는 방향을 권장한다.
+- CI 권한·secret·Pages 변경은 Risky Change로 별도 phase와 관리자 승인을 요구한다. `pull_request_target`은 대안으로 사용하지 않는다.
+- worktree에는 local credential을 기본 복사하지 않고 Local handoff 또는 별도 보안 승인을 사용한다.
+
+## 변경
+
+- `docs/ai/codex-operation-hardening-plan.md`에 Phase 0~5의 수정 대상, 적용 정책, 체크리스트, exit gate, 위험과 승인 경계를 작성했다.
+- AI Docs README와 document registry에 새 primary roadmap을 등록하고 generated knowledge Index를 갱신했다.
+
+## 검증
+
+- `python3 scripts/ai/generate_knowledge_index.py --check`: 통과. shared 35개·local 3개 문서를 확인했다.
+- `python3 scripts/ai/verify_knowledge_graph.py`: 완료 record의 전역 skill 참조를 project registry 형식으로 정정한 뒤 재실행한다.
+- `python3 -m unittest discover -s scripts/ai/tests -p 'test_*.py'`: 11 tests 통과.
+- `git diff --check`: 통과.
+- 문서·registry·generated Index만 변경했으므로 Gradle 검증은 실행하지 않았다.
+
+## 지시 이행
+
+- 충족: 공식 Codex guide와 현재 project policy·CI·agent·worktree 조건을 함께 근거로 삼았다.
+- 충족: 수정이 필요한 모든 영역을 phase별 변경 대상, 체크리스트, exit gate, 승인 경계로 문서화했다.
+- 충족: OAuth secret, `local.properties`, keystore의 내용을 읽거나 문서화하지 않았다.
+- 충족: 구현·commit·push·GitHub 설정 변경은 수행하지 않았다.
+- 충족: 사용자 untracked `docs/multi-module-migration-template.md`는 변경·stage·commit하지 않았다.
+
+## 스킬 평가
+
+- `project-knowledge-grounding`: 현재 운영 문서와 실제 CI·Gradle 설정을 함께 선택해 정책이 추측이 되지 않도록 했다.
+- `session-retrospective`: 작업 이력, generated Index, graph verifier와 registry 참조의 오류를 종료 전에 발견·정정하는 데 사용했다.
+- 전역 `openai-docs` system skill: 최신 Codex manual의 공식 원칙을 확인하는 데 사용했다. project skill registry에는 등록 대상이 아니므로 frontmatter 목록에서는 제외했다.
+
+## 개선 후보
+
+- Phase 1을 실제 적용할 때 custom agent read-only sandbox가 parent runtime permission과 충돌하지 않는지, reviewer 1개를 대상으로 수동 검증한다.
+- Phase 2의 non-secret OAuth placeholder가 현재 전체 Gradle command를 통과하지 않으면 credential-free BuildConfig 분리를 별도 Risky Change로 승격한다.

--- a/docs/history/records/2026/2026-08-01-cross-project-operation-principles-template.md
+++ b/docs/history/records/2026/2026-08-01-cross-project-operation-principles-template.md
@@ -1,0 +1,49 @@
+---
+id: GS-2026-0012
+status: completed
+base_commit: b6bba07
+related_documents: [ai-readme, knowledge-operations, codex-operation-hardening-plan, cross-project-operation-principles-template, history-readme]
+related_code: [docs/ai, .codex, .githooks, .github]
+skills_used: [project-knowledge-grounding, session-retrospective]
+---
+
+# Cross-project Codex 운영 원칙 초안
+
+## 요청
+
+- 현재 운영 보강 작업에서 다른 repository에도 재사용할 수 있는 공통 원칙을 docs에 기록하고, 모든 phase 완료 후 다시 다듬을 수 있게 한다.
+
+## 근거
+
+- Phase 0~2에서 정책·agent read-only·CI 최소 권한과 secret-free build 원칙을 GithubSearch 적용본으로 구현했다.
+- branch, Gradle task, OAuth 입력, deployment은 repository별로 달라 그대로 복사하면 안 된다.
+
+## 결정
+
+- 공통 원칙과 project-specific 조정 항목을 분리한 provisional template를 만든다.
+- Phase 3~5의 worktree, review, 운영 결과를 반영하기 전에는 shared bootstrap 또는 global skill로 승격하지 않는다.
+
+## 변경
+
+- `docs/ai/cross-project-operation-principles-template.md`에 최소 권한, secret-free PR 검증, reviewer/write 분리, worktree, 보고, phase 운영 원칙을 기록했다.
+- AI docs 목차와 document registry에 템플릿을 등록했다.
+
+## 검증
+
+- `python3 scripts/ai/generate_knowledge_index.py --check`: 통과.
+- `python3 scripts/ai/verify_knowledge_graph.py`: 0 error, 0 warning.
+- `git diff --check`: 통과.
+- 문서-only 변경이므로 Gradle 검증은 실행하지 않았다.
+
+## 지시 이행
+
+- fulfilled: 공통 원칙을 provisional template로 기록했고, 후속 phase 완료 뒤 재검토할 항목을 명시했다.
+
+## 스킬 평가
+
+- `project-knowledge-grounding`: 현재 적용본과 registry 경계를 확인해 공통·project-specific 내용을 분리하는 데 충분했다.
+- `session-retrospective`: 문서 관계와 작업 이력 검증을 종료 기준으로 적용한다.
+
+## 개선 후보
+
+- Phase 3~5 완료 후 실제 원격 CI·worktree·review 결과를 반영해 이 템플릿의 항목을 승격, 완화, 제거한다.

--- a/docs/history/records/2026/2026-08-01-subagent-operation-navigation-contract.md
+++ b/docs/history/records/2026/2026-08-01-subagent-operation-navigation-contract.md
@@ -1,0 +1,64 @@
+---
+id: GS-2026-0007
+status: completed
+base_commit: bcc9e0f
+related_documents: [knowledge-operations, subagents, navigation-contracts, task-scope, quality-gates, history-readme]
+related_code: [.codex/agents, docs/ai/registry, docs/ai, app, feature/detail]
+skills_used: [project-knowledge-grounding, session-retrospective]
+---
+
+# Custom agent 운영 전환과 navigation 계약 정립
+
+## 요청
+
+- 기존 4개 custom agent를 초안이 아닌 실제 운영 상태로 전환하고, `navigation-contract-reviewer`를 추가한다.
+- 모든 agent가 결론 전에 관련 정본 문서와 영향 코드·테스트를 읽고 두 근거 경로를 결과에 남기도록 통일한다.
+- 현재 구현을 근거로 navigation 계약 문서를 만들되, SmartTimer의 타이머·알림·진동 역할은 이식하지 않는다.
+
+## 근거
+
+- `app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt`의 `NavHost`는 `HOME`을 start destination으로 두고, Detail route를 `DETAIL/{id}?from={from}`으로 선언한다.
+- 같은 파일에서 Home 일반 목록·검색 결과·Favorite가 각각 `home`·`search`·`favorite` 값을 전달하고, Detail은 `navigateUp()`으로 뒤로 간다.
+- 하단 navigation은 Detail에서 숨기며, 탭 전환에 `saveState`, `launchSingleTop`, `restoreState`를 사용한다.
+- `feature/detail/src/main/java/com/gyleedev/githubsearch/feature/detail/DetailViewModel.kt`와 해당 test는 `SavedStateHandle`의 `id` 수신·처리를 보여 준다. 현재 navigation 선언에서 deep link와 route 조립·back stack을 직접 검증하는 test는 찾지 못했다.
+- SmartTimer의 navigation agent와 registry는 review-first, 근거 경로 반환, scope 등록이라는 운영 방향의 참고로만 사용했다. timer lifecycle 역할과 AlarmManager·notification·vibration 관련 문서는 이식하지 않았다.
+
+## 결정
+
+- 기존 4개 agent와 새 navigation agent를 실제 운영 상태로 정의하되, 기본 권한은 review-first·read-only로 고정한다.
+- agent의 파일 수정은 주 작업자가 명시한 제한된 write scope에서만 허용한다. 최종 적용, 위험 판단, 검증, 보고 책임은 주 작업자에게 남긴다.
+- 모든 agent는 관련 primary document와 현재 영향 코드 또는 테스트를 읽고 두 근거 경로를 결과에 남긴다.
+- navigation 계약은 현재 route 문자열, argument, 호출자, back stack, 탭 상태 보존, 하단 바 표시 조건만 기록한다. type-safe navigation 및 deep link 도입은 구현하지 않는다.
+
+## 변경
+
+- 기존 4개 `.codex/agents/*.toml`에 공통 근거 경로 반환 규칙을 추가하고, 기존 review-first·제한된 write·Git·secret·위험 변경 guardrail을 유지했다.
+- `.codex/agents/navigation-contract-reviewer.toml`을 추가했다. navigation route, argument, caller/destination compatibility, deep link, back stack, 상태 복원과 behavior test 필요성만 검토한다.
+- `docs/ai/registry/agents.toml`의 모든 agent에 사람이 읽는 `scope`와 `knowledge-operations` 필수 문서를 추가하고, navigation agent를 등록했다.
+- `docs/ai/navigation-contracts.md`와 registry document를 추가하고, `subagents.md`, `README.md`, generated knowledge Index를 실제 운영 상태로 갱신했다.
+
+## 검증
+
+- `python3 scripts/ai/generate_knowledge_index.py --check`: 통과. shared 34개·local 3개 문서, agent 5개를 확인했다.
+- `python3 scripts/ai/verify_knowledge_graph.py`: 0 error, 0 warning 통과.
+- `python3 -m unittest discover -s scripts/ai/tests -p 'test_*.py'`: 11 tests 통과.
+- `git diff --check`: 통과.
+- 문서·custom agent 설정·generated Index만 변경했으며 Android 코드, Gradle, navigation 동작을 변경하지 않아 Gradle 검증은 실행하지 않았다.
+
+## 지시 이행
+
+- 충족: 기존 4개 역할을 초안 표현에서 실제 운영 문서·registry 구성으로 전환했다.
+- 충족: 모든 agent에 문서와 현재 코드/테스트 근거 경로 반환 규칙을 적용했다.
+- 충족: navigation 계약 문서는 현재 구현 근거만 기록했고, deep link·route·Gradle 동작은 바꾸지 않았다.
+- 충족: SmartTimer의 timer lifecycle, AlarmManager, notification, vibration 관련 역할과 문서는 가져오지 않았다.
+- 충족: 사용자 untracked `docs/multi-module-migration-template.md`는 변경·stage·commit하지 않았다.
+- 충족: 이번 작업에서는 commit·push를 수행하지 않았다.
+
+## 스킬 평가
+
+- `project-knowledge-grounding`: AGENTS, knowledge operations, 범위·품질 규칙, agent registry, 현재 navigation 코드·test를 함께 읽어 문서 정본의 근거를 제한하는 데 사용했다.
+- `session-retrospective`: history 완료 기록, generated Index, graph·회귀 검사, diff, 사용자 local 파일 보존을 종료 전에 점검하는 데 사용했다.
+
+## 개선 후보
+
+- navigation 동작을 바꾸는 후속 작업에서는 route 조립, `from` 값, `navigateUp`, 탭 상태 복원을 직접 검증하는 behavior test의 도입 여부를 `test-strategy-reviewer`와 함께 판단한다.

--- a/docs/knowledge/INDEX.md
+++ b/docs/knowledge/INDEX.md
@@ -43,6 +43,7 @@
 | `task-scope` | [docs/ai/task-scope-control.md](../../docs/ai/task-scope-control.md) | primary | `app, domain, data, feature, core, build-logic` |
 | `template-sync-policy` | [docs/ai/template-sync-policy.md](../../docs/ai/template-sync-policy.md) | primary | `docs, .codex` |
 | `testing-guide` | [docs/testing/TESTING_GUIDE.md](../../docs/testing/TESTING_GUIDE.md) | primary | `domain, data, feature, core/testing` |
+| `worktree-policy` | [docs/ai/worktree-policy.md](../../docs/ai/worktree-policy.md) | primary | `AGENTS.md, .codex, .gitignore, docs/ai` |
 
 ## reference
 
@@ -69,6 +70,7 @@
 | ID | 문서 | 권한 | 관련 코드 |
 |---|---|---|---|
 | `change-report` | [docs/ai/change-report-template.md](../../docs/ai/change-report-template.md) | primary | `AGENTS.md, docs/history, scripts/ai` |
+| `cross-project-operation-principles-template` | [docs/ai/cross-project-operation-principles-template.md](../../docs/ai/cross-project-operation-principles-template.md) | primary | `AGENTS.md, .codex, .githooks, .github, docs/ai` |
 | `knowledge-governance-enforcement-prompt` | [docs/ai/knowledge-governance-enforcement-prompt.md](../../docs/ai/knowledge-governance-enforcement-prompt.md) | primary | `docs, scripts/ai, .codex, .github` |
 
 ## workflow

--- a/docs/knowledge/INDEX.md
+++ b/docs/knowledge/INDEX.md
@@ -12,6 +12,7 @@
 | `data-logic` | [docs/ai/DATA_LOGIC_GUIDELINES.md](../../docs/ai/DATA_LOGIC_GUIDELINES.md) | primary | `domain, data, feature, core` |
 | `design-guide` | [docs/design/DESIGN_GUIDE.md](../../docs/design/DESIGN_GUIDE.md) | auxiliary | `app, feature, core` |
 | `liquid-navigation-guide` | [docs/design/LIQUID_NAVIGATION_GUIDE.md](../../docs/design/LIQUID_NAVIGATION_GUIDE.md) | auxiliary | `app, core, feature` |
+| `navigation-contracts` | [docs/ai/navigation-contracts.md](../../docs/ai/navigation-contracts.md) | primary | `app, feature/detail` |
 | `ui-guidelines` | [docs/ai/UI_GUIDELINES.md](../../docs/ai/UI_GUIDELINES.md) | primary | `app, feature, core` |
 
 ## index

--- a/docs/knowledge/INDEX.md
+++ b/docs/knowledge/INDEX.md
@@ -54,6 +54,7 @@
 
 | ID | 문서 | 권한 | 관련 코드 |
 |---|---|---|---|
+| `codex-operation-hardening-plan` | [docs/ai/codex-operation-hardening-plan.md](../../docs/ai/codex-operation-hardening-plan.md) | primary | `.codex, .githooks, .github, build-logic, app, data` |
 | `jacoco-setup-plan` | [docs/plan/JACOCO_SETUP_PLAN.md](../../docs/plan/JACOCO_SETUP_PLAN.md) | auxiliary | `build.gradle.kts, app, domain, data, feature, core` |
 | `knowledge-governance-enforcement-plan` | [docs/ai/knowledge-governance-enforcement-plan.md](../../docs/ai/knowledge-governance-enforcement-plan.md) | primary | `docs, scripts/ai, .codex, .github` |
 | `multi-module-refactoring-plan` | [docs/plan/MULTI_MODULE_REFACTORING_PLAN.md](../../docs/plan/MULTI_MODULE_REFACTORING_PLAN.md) | auxiliary | `settings.gradle.kts, build-logic, app, domain, data, feature, core` |

--- a/docs/knowledge/INDEX.md
+++ b/docs/knowledge/INDEX.md
@@ -57,6 +57,7 @@
 | `codex-operation-hardening-plan` | [docs/ai/codex-operation-hardening-plan.md](../../docs/ai/codex-operation-hardening-plan.md) | primary | `.codex, .githooks, .github, build-logic, app, data` |
 | `jacoco-setup-plan` | [docs/plan/JACOCO_SETUP_PLAN.md](../../docs/plan/JACOCO_SETUP_PLAN.md) | auxiliary | `build.gradle.kts, app, domain, data, feature, core` |
 | `knowledge-governance-enforcement-plan` | [docs/ai/knowledge-governance-enforcement-plan.md](../../docs/ai/knowledge-governance-enforcement-plan.md) | primary | `docs, scripts/ai, .codex, .github` |
+| `liquid-navigation-ui-follow-up-plan` | [docs/plan/LIQUID_NAVIGATION_UI_FOLLOW_UP_PLAN.md](../../docs/plan/LIQUID_NAVIGATION_UI_FOLLOW_UP_PLAN.md) | auxiliary | `app, feature/setting, core/designsystem` |
 | `multi-module-refactoring-plan` | [docs/plan/MULTI_MODULE_REFACTORING_PLAN.md](../../docs/plan/MULTI_MODULE_REFACTORING_PLAN.md) | auxiliary | `settings.gradle.kts, build-logic, app, domain, data, feature, core` |
 | `reporting-system-migration-plan` | [docs/ai/reporting-system-migration-plan.md](../../docs/ai/reporting-system-migration-plan.md) | primary | `docs, scripts/ai, .codex` |
 | `screenshot-test-plan` | [docs/testing/SCREENSHOT_TEST_IMPLEMENTATION_PLAN.md](../../docs/testing/SCREENSHOT_TEST_IMPLEMENTATION_PLAN.md) | primary | `gradle, feature/setting, core/designsystem, .github` |

--- a/docs/knowledge/INDEX.md
+++ b/docs/knowledge/INDEX.md
@@ -37,6 +37,7 @@
 | ID | 문서 | 권한 | 관련 코드 |
 |---|---|---|---|
 | `ai-coding-guidelines` | [docs/ai/CODING_GUIDELINES.md](../../docs/ai/CODING_GUIDELINES.md) | auxiliary | `app, domain, data, feature, core` |
+| `code-review` | [docs/ai/code-review.md](../../docs/ai/code-review.md) | primary | `AGENTS.md, .codex/agents, .githooks, .github, docs/ai` |
 | `coding-conventions` | [docs/ai/android-coding-conventions.md](../../docs/ai/android-coding-conventions.md) | primary | `app, domain, data, feature, core, build-logic` |
 | `convention` | [docs/CONVENTION.md](../../docs/CONVENTION.md) | auxiliary | `app, domain, data, feature, core` |
 | `quality-gates` | [docs/ai/quality-gates.md](../../docs/ai/quality-gates.md) | primary | `build.gradle.kts, .github, scripts/ai` |

--- a/docs/plan/JACOCO_SETUP_PLAN.md
+++ b/docs/plan/JACOCO_SETUP_PLAN.md
@@ -35,7 +35,7 @@
 - **Workflow 작성**: `.github/workflows/jacoco-report.yml`
     - 트리거: `pull_request` (target: main, develop)
     - 명령어: `./gradlew testDebugUnitTest jacocoFullReport` (통합 리포트 생성)
-- **GitHub Pages 배포**: `main` 브랜치 머지 시 전체 커버리지 HTML 리포트를 배포하여 히스토리를 관리합니다.
+- **GitHub Pages 배포**: 기본 통합 브랜치인 `develop` 머지 시 전체 커버리지 HTML 리포트를 배포합니다. 하나의 Pages 사이트를 `main`과 공유하지 않아 어느 브랜치의 리포트인지 혼동되지 않게 합니다.
 
 ### 4단계: PR Comment 피드백 자동화
 - **Madrapps/jacoco-report 액션 연동**:

--- a/docs/plan/LIQUID_NAVIGATION_UI_FOLLOW_UP_PLAN.md
+++ b/docs/plan/LIQUID_NAVIGATION_UI_FOLLOW_UP_PLAN.md
@@ -1,0 +1,91 @@
+# Liquid Navigation UI 수정 후보
+
+> **Status:** proposed — 아직 구현하지 않음
+>
+> **Source:** `compose-ui-reviewer`의 Phase 1 runtime 검토 결과와 현재 Compose 코드
+>
+> **Purpose:** Liquid navigation overlay와 접근성·시각 회귀 검증에서 확인된 가능성을 구현 작업과 분리해 기록한다.
+
+## 범위와 비범위
+
+이 문서는 수정 후보, 근거, 검증 방법만 기록한다. 아래 후보는 아직 재현 테스트나 화면 변경으로 확정된 버그가 아니다.
+
+- 포함: Setting 화면의 overlay 안전 영역, 하단 탭 접근성 그룹, Liquid navigation Preview·시각 회귀 검증
+- 제외: navigation route·back stack·OAuth 동작, 새로운 screenshot Gradle plugin 또는 dependency, 디자인 색상·타이포그래피 재설계
+- 구현 전: `compose-ui-reviewer`와 `test-strategy-reviewer`의 근거 기반 검토를 다시 요청하고, 작은 범위의 별도 작업으로 진행한다.
+
+## 현재 근거
+
+- [Liquid Navigation Guide](../design/LIQUID_NAVIGATION_GUIDE.md)는 navigation bar가 `Scaffold` 바깥의 overlay이고, 각 화면의 마지막 콘텐츠가 bar 위까지 스크롤될 하단 여유를 가져야 한다고 정의한다.
+- `GithubSearchScreen`은 Detail 외 화면에 `BottomNavigation`을 `Box`의 하단 overlay로 표시한다.
+- `SettingScreen`은 기본 `Scaffold`의 `paddingValues`를 전체 `SettingMainBlock`에 적용한다.
+- `LiquidNavigationBar`의 각 탭은 `Role.Tab`을 가진 `selectable`이지만 상위 `Row`는 selection group을 선언하지 않는다.
+- 현재 `LiquidNavigationBar`에는 Light/Dark Preview 또는 navigation 동작을 직접 검증하는 UI/instrumentation/screenshot test가 없다.
+
+## 후보 1 — Setting 화면의 하단 overlay 안전 영역
+
+**우선순위:** Medium — 사용자 화면에서 콘텐츠 또는 Snackbar가 가려질 가능성
+
+**관련 경로:**
+
+- `feature/setting/src/main/java/com/gyleedev/githubsearch/feature/setting/SettingScreen.kt`
+- `app/src/main/java/com/gyleedev/githubsearch/ui/GithubSearchScreen.kt`
+- `docs/design/LIQUID_NAVIGATION_GUIDE.md`
+
+**가능성:** Setting 화면은 기본 `Scaffold` inset과 `paddingValues`를 사용하지만, Liquid navigation은 앱 shell의 overlay다. compact landscape 또는 큰 글꼴에서 마지막 설정 항목·Snackbar가 bar와 겹칠 수 있다. 현재 OAuth AuthTab이 전면에 있어 runtime 화면으로는 아직 재현하지 못했다.
+
+**수정 전 확인:**
+
+1. Home·Favorite와 Setting의 Scaffold/inset·마지막 콘텐츠 여유 방식을 코드에서 비교한다.
+2. emulator에서 portrait, landscape, 큰 글꼴에서 마지막 설정 항목과 Snackbar를 확인한다.
+3. 겹침이 실제로 재현될 때만 Setting의 자체 scaffold/inset 또는 list 하단 여유를 최소 변경으로 정렬한다.
+
+**최소 검증:** 변경 화면의 수동 확인, `./gradlew :feature:setting:compileDebugKotlin` 또는 관련 `assembleDebug`, 필요한 경우 screenshot test 도입 계획과 분리된 UI 검증.
+
+## 후보 2 — Liquid navigation 탭의 접근성 선택 그룹
+
+**우선순위:** Low — TalkBack 등 접근성 서비스의 탭 묶음 인식 개선 가능성
+
+**관련 경로:**
+
+- `app/src/main/java/com/gyleedev/githubsearch/ui/LiquidNavigationBar.kt`
+
+**가능성:** 각 탭은 `Role.Tab`을 전달하지만 탭을 감싸는 `Row`에는 `selectableGroup()`이 없다. group semantics를 추가하면 선택 항목이 하나의 탭 집합이라는 정보를 접근성 서비스에 더 명확히 제공할 수 있다.
+
+**수정 전 확인:** 현재 Compose semantics tree와 TalkBack에서 선택 상태·순서가 실제로 부족한지 확인한다.
+
+**최소 수정 후보:** 탭 `Row`에 group semantics만 추가하고, 선택 동작·route·색상·애니메이션은 바꾸지 않는다.
+
+**최소 검증:** Compose semantics 또는 device TalkBack 확인, `./gradlew :app:compileDebugKotlin`, 선택된 탭과 비선택 탭의 접근성 label 수동 확인.
+
+## 후보 3 — Liquid navigation Preview와 시각 회귀 검증
+
+**우선순위:** Low — 테마·레이아웃 회귀를 조기에 확인할 수 있는 기반
+
+**관련 경로:**
+
+- `app/src/main/java/com/gyleedev/githubsearch/ui/LiquidNavigationBar.kt`
+- `docs/ai/UI_GUIDELINES.md`
+- `docs/testing/SCREENSHOT_TEST_IMPLEMENTATION_PLAN.md`
+
+**가능성:** Liquid navigation은 light/dark 테마, 선택 탭, 폭에 따라 glass와 pill 위치가 달라지지만 해당 상태를 고정해 보는 Preview가 없다. screenshot test plugin은 아직 도입 전이므로 지금 새 dependency를 추가하지 않는다.
+
+**수정 전 확인:** Preview에 필요한 static state와 callback을 production navigation controller 없이 전달할 수 있는지 확인한다.
+
+**최소 수정 후보:** `LiquidNavigationBar`의 선택 route를 고정한 Light/Dark Preview를 추가한다. screenshot test는 기존 도입 계획의 승인·Phase와 별도 진행한다.
+
+**최소 검증:** Android Studio Preview 확인, `./gradlew :app:compileDebugKotlin`; screenshot test는 plugin 도입 승인 후에만 `validateDebugScreenshotTest`를 사용한다.
+
+## 구현 순서와 완료 기준
+
+| 순서 | 후보 | 실행 조건 | 완료 기준 |
+| --- | --- | --- | --- |
+| 1 | Setting overlay | 실제 겹침 재현 또는 코드 근거 재확인 | 마지막 항목·Snackbar가 portrait/landscape/큰 글꼴에서 가려지지 않음 |
+| 2 | tab group semantics | semantics 또는 TalkBack 확인 | 세 탭이 하나의 선택 그룹으로 읽히고 선택 동작 유지 |
+| 3 | Preview | static state 분리 가능 | Light/Dark Preview에서 세 탭과 선택 상태 확인 |
+
+각 후보는 별도 Small 작업으로 처리한다. route, navigation 동작, screenshot Gradle plugin, UI 구조 전면 변경으로 범위가 커지면 `docs/ai/task-scope-control.md`의 Risky Change 절차로 중단하고 계획을 갱신한다.
+
+## 현재 결론
+
+세 항목은 수정 후보이며, 앱 동작 결함으로 확정하지 않았다. 다음 UI 작업에서 실제 재현·접근성 확인을 먼저 수행한 뒤 최소 변경만 적용한다.


### PR DESCRIPTION
## 변경 사항

- build job에서 production OAuth secret과 Gradle cache encryption secret을 제거하고, 비밀이 아닌 CI placeholder로 Gradle 검증을 수행합니다.
- PR coverage comment와 GitHub Pages 배포를 별도 최소 권한 job으로 분리합니다.
- fork PR에서는 coverage comment job을 실행하지 않습니다.
- CI 권한 모델과 Phase 2 작업 이력을 문서화합니다.

## 확인할 CI 항목

- Build & Coverage가 non-secret placeholder 환경에서 통과하는지
- internal PR에서 JaCoCo PR Comment가 정상 동작하는지
- PR에서는 Deploy Coverage Pages가 실행되지 않는지
- Knowledge verification이 통과하는지

## 로컬 검증

- non-secret placeholder 환경의 CI full Gradle command 실행 및 JaCoCo report 생성 확인
- workflow YAML parse
- knowledge index / graph 검증
- 정책 unittest 11개 통과